### PR TITLE
Rework document into two part: separate HEIF construction details from AVIF profile

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -7,6 +7,14 @@
 	"publisher": "AOM"
     },
 
+    "AV1-ISOBMFF": {
+	"href": "https://aomediacodec.github.io/av1-isobmff/",
+	"id": "AV1-ISOBMFF",
+	"title": "AV1 Codec ISO Media File Format Binding",
+	"status": "LS",
+	"publisher": "AOM"
+    },
+
     "HEIF": {
 	"id": "HEIF",
 	"href": "https://www.iso.org/standard/66067.html",

--- a/biblio.json
+++ b/biblio.json
@@ -1,17 +1,27 @@
 {
-	"AV1": {
-		"href": "http://av1-spec.argondesign.com/av1-spec/av1-spec.html",
-		"title": "AV1 Bitstream & Decoding Process Specification",
-		"status": "LS",
-		"publisher": "AOM"
-	},
+    "AV1": {
+	"href": "http://av1-spec.argondesign.com/av1-spec/av1-spec.html",
+	"id": "AV1",
+	"title": "AV1 Bitstream & Decoding Process Specification",
+	"status": "LS",
+	"publisher": "AOM"
+    },
 
     "HEIF": {
-	"date": "December 2017",
 	"id": "HEIF",
 	"href": "https://www.iso.org/standard/66067.html",
 	"title": "Information technology — High efficiency coding and media delivery in heterogeneous environments — Part 12: Image File Format",
 	"status": "International Standard",
-	"publisher": "ISO/IEC"
+	"publisher": "ISO/IEC",
+	"isoNumber":"ISO/IEC 23008-12:2017"
+    },
+
+    "MIAF": {
+	"href": "https://www.iso.org/standard/74417.html",
+	"id": "MIAF",
+	"title": "Information technology -- Multimedia application format (MPEG-A) -- Part 22: Multi-Image Application Format (MiAF)",
+	"status": "Enquiry",
+	"publisher": "ISO/IEC",
+	"isoNumber": "ISO/IEC DIS 23000-22"
     }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
 <!doctype html><html lang="en">
  <head>
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
-  <title>AV1 Still Image File Format (AVIF)</title>
+  <title>AV1 Image File Format (AVIF)</title>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
 <style data-fill-with="stylesheet">/******************************************************************************
  *                   Style sheet for the W3C specifications                   *
@@ -1178,7 +1178,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version b740b15097946bf1d13405dc6d7ca5a72fa2530d" name="generator">
   <link href="https://AOMediaCodec.github.io/av1-avif" rel="canonical">
-  <meta content="3dd5c44b37537c4063afb0cced961618a4941c31" name="document-revision">
+  <meta content="c73351465aab39e57d159b159ac711af3be32846" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1218,43 +1218,6 @@ figcaption {
 figcaption:not(.no-marker)::before {
     content: "Figure " counter(figure) " ";
 }</style>
-<style>/* style-dfn-panel */
-
-        .dfn-panel {
-            position: absolute;
-            z-index: 35;
-            height: auto;
-            width: -webkit-fit-content;
-            width: fit-content;
-            max-width: 300px;
-            max-height: 500px;
-            overflow: auto;
-            padding: 0.5em 0.75em;
-            font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
-            background: #DDDDDD;
-            color: black;
-            border: outset 0.2em;
-        }
-        .dfn-panel:not(.on) { display: none; }
-        .dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
-        .dfn-panel > b { display: block; }
-        .dfn-panel a { color: black; }
-        .dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
-        .dfn-panel > b + b { margin-top: 0.25em; }
-        .dfn-panel ul { padding: 0; }
-        .dfn-panel li { list-style: inside; }
-        .dfn-panel.activated {
-            display: inline-block;
-            position: fixed;
-            left: .5em;
-            bottom: 2em;
-            margin: 0 auto;
-            max-width: calc(100vw - 1.5em - .4em - .5em);
-            max-height: 30vh;
-        }
-
-        .dfn-paneled { cursor: pointer; }
-        </style>
 <style>/* style-selflinks */
 
 .heading, .issue, .note, .example, li, dt {
@@ -1366,8 +1329,8 @@ pre .property::before, pre .property::after {
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"></p>
-   <h1 class="p-name no-ref" id="title">AV1 Still Image File Format (AVIF)</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2018-05-09">9 May 2018</time></span></h2>
+   <h1 class="p-name no-ref" id="title">AV1 Image File Format (AVIF)</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2018-06-03">3 June 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1387,92 +1350,59 @@ pre .property::before, pre .property::after {
    <p class="copyright" data-fill-with="copyright">
     <p>Copyright 2018, The Alliance for Open Media</p>
     <p>Licensing information is available at http://aomedia.org/license/</p>
-    <p> The MATERIALS ARE PROVIDED “AS IS.” The Alliance for Open Media, its members, and its contributors
-  expressly disclaim any warranties (express, implied, or otherwise), including implied warranties of
-  merchantability, non-infringement, fitness for a particular purpose, or title, related to the materials.
-  The entire risk as to implementing or otherwise using the materials is assumed by the implementer and user.
-  IN NO EVENT WILL THE ALLIANCE FOR OPEN MEDIA, ITS MEMBERS, OR CONTRIBUTORS BE LIABLE TO ANY OTHER PARTY
-  FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER
-  FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS DELIVERABLE OR ITS GOVERNING AGREEMENT,
-  WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT
-  THE OTHER MEMBER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGEd. </p>
+    <p>The MATERIALS ARE PROVIDED “AS IS.” The Alliance for Open Media, its members, and its contributors
+expressly disclaim any warranties (express, implied, or otherwise), including implied warranties of
+merchantability, non-infringement, fitness for a particular purpose, or title, related to the materials.
+The entire risk as to implementing or otherwise using the materials is assumed by the implementer and user.
+IN NO EVENT WILL THE ALLIANCE FOR OPEN MEDIA, ITS MEMBERS, OR CONTRIBUTORS BE LIABLE TO ANY OTHER PARTY
+FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER
+FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS DELIVERABLE OR ITS GOVERNING AGREEMENT,
+WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT
+THE OTHER MEMBER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </p>
    </p>
    <hr title="Separator for header">
   </div>
   <div class="p-summary" data-fill-with="abstract">
    <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
-   <p>This document contains a set of requirements that can be used to contain a one or more <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> still images in a file using structures defined by the a <a data-link-type="biblio" href="#biblio-isobmff">[ISOBMFF]</a> and <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a> specifications meant to allow for a mimumum set of features to allow the interchange of files between AVIF writers and readers. The file format described here conforms to the interoperability rules as defined in MIAF as applied to the structures used within this specification. AVIF respresents a functional subset of the features and attributes defined in the codec agnostic sections of HEIF.</p>
+   <p>This document contains a set of requirements that can be used to incorporate one or more <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> still images in a file using structures and procedures defined by the <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a> specification. This specification defines a set of minimum requirements to allow the interchange of files between AVIF writers and readers.</p>
   </div>
   <div data-fill-with="at-risk"></div>
   <nav data-fill-with="table-of-contents" id="toc">
    <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
    <ol class="toc" role="directory">
+    <li><a href="#general"><span class="secno">1</span> <span class="content">General</span></a>
     <li>
-     <a href="#overview"><span class="secno">1</span> <span class="content">Overview</span></a>
+     <a href="#avif=image-collection"><span class="secno">2</span> <span class="content">AVIF Image Collection</span></a>
      <ol class="toc">
-      <li><a href="#target-features"><span class="secno">1.1</span> <span class="content">Target Features</span></a>
+      <li><a href="#av1-image-samples"><span class="secno">2.1</span> <span class="content">AV1 Image Data</span></a>
+      <li><a href="#av1-configuration-item-property"><span class="secno">2.2</span> <span class="content">AV1 Configuration Item Property</span></a>
      </ol>
     <li>
-     <a href="#terms-and-definitions"><span class="secno">2</span> <span class="content">Terms and Definitions</span></a>
+     <a href="#avif-image-sequence"><span class="secno">3</span> <span class="content">AVIF Image Sequence</span></a>
      <ol class="toc">
-      <li><a href="#def-alpha-image"><span class="secno">2.1</span> <span class="content"><span>Alpha Image</span></span></a>
-      <li><a href="#def-auxiliary-image"><span class="secno">2.2</span> <span class="content"><span>Auxiliary Image</span></span></a>
-      <li><a href="#def-cover-image"><span class="secno">2.3</span> <span class="content"><span>Cover Image</span></span></a>
-      <li><a href="#def-image-collection"><span class="secno">2.4</span> <span class="content"><span>Image Collection</span></span></a>
-      <li><a href="#def-image-properties"><span class="secno">2.5</span> <span class="content"><span>Image Properties</span></span></a>
-      <li><a href="#def-image-sequence"><span class="secno">2.6</span> <span class="content"><span>Image Sequence</span></span></a>
-      <li><a href="#def-master-image"><span class="secno">2.7</span> <span class="content"><span>Master Image</span></span></a>
-      <li><a href="#def-metadata"><span class="secno">2.8</span> <span class="content"><span>Metadata</span></span></a>
-      <li><a href="#def-thumbnail-image"><span class="secno">2.9</span> <span class="content"><span>Thumbnail Image</span></span></a>
+      <li><a href="#avif-image-tracks"><span class="secno">3.1</span> <span class="content">AVIF Image Tracks</span></a>
+      <li><a href="#av1-visual-sample-entryy"><span class="secno">3.2</span> <span class="content">AV1 Visual Sample Entry</span></a>
      </ol>
+    <li><a href="#alpha-images"><span class="secno">4</span> <span class="content">Alpha Images</span></a>
+    <li><a href="#avif_brands"><span class="secno">5</span> <span class="content">Brands</span></a>
     <li>
-     <a href="#object-model-and-structure"><span class="secno">3</span> <span class="content">Object Model and Structure</span></a>
+     <a href="#AVIF-version-1.0-profile"><span class="secno">6</span> <span class="content">AVIF Version 1.0 Profile</span></a>
      <ol class="toc">
-      <li><a href="#image-storage"><span class="secno">3.1</span> <span class="content">Image Storage</span></a>
-      <li><a href="#image-collection-elements"><span class="secno">3.2</span> <span class="content">Image Collection Elements</span></a>
-      <li><a href="#image-sequence-elements"><span class="secno">3.3</span> <span class="content">Image Sequence Elements</span></a>
-      <li><a href="#thumbnails"><span class="secno">3.4</span> <span class="content">Thumbnails</span></a>
-      <li><a href="#cover-image①"><span class="secno">3.5</span> <span class="content">Cover Image</span></a>
-      <li><a href="#alpha-channel"><span class="secno">3.6</span> <span class="content">Alpha Channel</span></a>
-      <li><a href="#metadata①"><span class="secno">3.7</span> <span class="content">Metadata</span></a>
-     </ol>
-    <li>
-     <a href="#file-format"><span class="secno">4</span> <span class="content">File Format</span></a>
-     <ol class="toc">
-      <li>
-       <a href="#common-elements"><span class="secno">4.1</span> <span class="content">Common Elements</span></a>
-       <ol class="toc">
-        <li><a href="#file-type-box"><span class="secno">4.1.1</span> <span class="content">FileTypeBox</span></a>
-       </ol>
-      <li>
-       <a href="#collection-elements"><span class="secno">4.2</span> <span class="content">Collection Elements</span></a>
-       <ol class="toc">
-        <li><a href="#meta-box"><span class="secno">4.2.1</span> <span class="content">MetaBox</span></a>
-        <li><a href="#handler-box"><span class="secno">4.2.2</span> <span class="content">HandlerBox</span></a>
-        <li><a href="#primary-item-box"><span class="secno">4.2.3</span> <span class="content">PrimaryItemBox</span></a>
-        <li><a href="#item-location-box"><span class="secno">4.2.4</span> <span class="content">ItemLocationBox</span></a>
-        <li><a href="#item-properties-box"><span class="secno">4.2.5</span> <span class="content">ItemPropertiesBox</span></a>
-        <li><a href="#item-info-box"><span class="secno">4.2.6</span> <span class="content">ItemInfoBox</span></a>
-        <li><a href="#item-reference-box"><span class="secno">4.2.7</span> <span class="content">ItemReferenceBox</span></a>
-        <li><a href="#item-data-box"><span class="secno">4.2.8</span> <span class="content">ItemDataBox</span></a>
-       </ol>
-      <li>
-       <a href="#sequence-elements"><span class="secno">4.3</span> <span class="content">Sequence Elements</span></a>
-       <ol class="toc">
-        <li><a href="#movie-box"><span class="secno">4.3.1</span> <span class="content">MovieBox</span></a>
-        <li><a href="#track-header-box"><span class="secno">4.3.2</span> <span class="content">TrackHeaderBox</span></a>
-        <li><a href="#track-reference-box"><span class="secno">4.3.3</span> <span class="content">TrackReferenceBox</span></a>
-        <li><a href="#media-box"><span class="secno">4.3.4</span> <span class="content">MediaBox</span></a>
-        <li><a href="#sample-table-box"><span class="secno">4.3.5</span> <span class="content">SampleTableBox</span></a>
-        <li><a href="#data-reference-box"><span class="secno">4.3.6</span> <span class="content">DataReferenceBox</span></a>
-       </ol>
+      <li><a href="#ver1-image-storage"><span class="secno">6.1</span> <span class="content">Image Storage</span></a>
+      <li><a href="#ver1-thumbnails"><span class="secno">6.2</span> <span class="content">Thumbnails</span></a>
+      <li><a href="#ver1-cover-image"><span class="secno">6.3</span> <span class="content">Cover Image</span></a>
+      <li><a href="#ver1-auxiliary-images"><span class="secno">6.4</span> <span class="content">Auxiliary Images</span></a>
+      <li><a href="#ver1-alpha-channel"><span class="secno">6.5</span> <span class="content">Alpha Channel</span></a>
+      <li><a href="#ver1-sample-groups"><span class="secno">6.6</span> <span class="content">Sample Groups</span></a>
+      <li><a href="#ver1-hidden-images"><span class="secno">6.7</span> <span class="content">Hidden Images</span></a>
+      <li><a href="#ver1-pre-derived-images"><span class="secno">6.8</span> <span class="content">Pre-Derived Coded Images</span></a>
+      <li><a href="#ver1-multi-layer-images"><span class="secno">6.9</span> <span class="content">Multi-Layer Images</span></a>
+      <li><a href="#ver1-derived-images"><span class="secno">6.10</span> <span class="content">Derived Images</span></a>
+      <li><a href="#ver1-metadata"><span class="secno">6.11</span> <span class="content">Metadata</span></a>
+      <li><a href="#collection-elements"><span class="secno">6.12</span> <span class="content">Collection Elements</span></a>
+      <li><a href="#sequence-elements"><span class="secno">6.13</span> <span class="content">Sequence Elements</span></a>
      </ol>
     <li><a href="#conformance"><span class="secno"></span> <span class="content"> Conformance</span></a>
-    <li>
-     <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
-     <ol class="toc">
-      <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
-     </ol>
     <li>
      <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
      <ol class="toc">
@@ -1481,116 +1411,103 @@ pre .property::before, pre .property::after {
    </ol>
   </nav>
   <main>
-   <h2 class="heading settled" data-level="1" id="overview"><span class="secno">1. </span><span class="content">Overview</span><a class="self-link" href="#overview"></a></h2>
-   <p> AVIF is a file format wrapping compressed images based on the <a href="http://aomedia.org">Alliance for Open Media</a> AV1 intra-frame encoding toolkit.
-  AVIF supports High Dynamic Range (HDR) and wide color gamut (WCG) images as well as standard
-  dynamic range (SDR). Only the intra-frame encoding toolkit is used in AVIF version 1.0. Using
-  the intra-frame encoding mechanism from an existing video codec standard has a precedent in WebP:
-  VP8, and HEIF: HEVC. This document describes at a high level a proposal on the structure of AVIF version 1.0. </p>
-   <p> The initial version of AVIF seeks to be simple, with just enough structure to allow the distribution
-  of images based on the AV1 intra-frame coding toolset. At its core, AVIF 1.0 will allow for one or more
-  images plus all supporting data needed to correctly reconstruct and display the images to be conveyed
-  in a file. The ability to embed a thumbnail image will also be provided. An image sequence with suggested
-  playback timing may be defined. </p>
-   <h3 class="heading settled" data-level="1.1" id="target-features"><span class="secno">1.1. </span><span class="content">Target Features</span><a class="self-link" href="#target-features"></a></h3>
-   <ul>
-    <li>AV1 intra-frame codec toolkit
-    <li>Multiple image storage: untimed unordered collection
-    <li>Animation: timed sequence of images
-    <li>Thumbnail image
-    <li>Alpha channel
-    <li>Extensible image metadata
-   </ul>
-   <h2 class="heading settled" data-level="2" id="terms-and-definitions"><span class="secno">2. </span><span class="content">Terms and Definitions</span><a class="self-link" href="#terms-and-definitions"></a></h2>
-   <h3 class="heading settled" data-level="2.1" id="def-alpha-image"><span class="secno">2.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="alpha-image">Alpha Image</dfn></span><a class="self-link" href="#def-alpha-image"></a></h3>
-   <p> A specific type of <a data-link-type="dfn" href="#auxiliary-image" id="ref-for-auxiliary-image">Auxiliary Image</a> that may be used to convey information representing
-  the opacity of associated <a data-link-type="dfn" href="#master-image" id="ref-for-master-image">Master Images</a>. </p>
-   <h3 class="heading settled" data-level="2.2" id="def-auxiliary-image"><span class="secno">2.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="auxiliary-image">Auxiliary Image</dfn></span><a class="self-link" href="#def-auxiliary-image"></a></h3>
-   <p> An image that is not be intended to be displayed but provides supplemental information for
-  associated <a data-link-type="dfn" href="#master-image" id="ref-for-master-image①">Master Images</a>. AVIF allows only one type of Auxiliary Image: an <a data-link-type="dfn" href="#alpha-image" id="ref-for-alpha-image">Alpha Image</a>. </p>
-   <h3 class="heading settled" data-level="2.3" id="def-cover-image"><span class="secno">2.3. </span><span class="content"><dfn data-dfn-type="dfn" data-noexport="" id="cover-image">Cover Image<a class="self-link" href="#cover-image"></a></dfn></span><a class="self-link" href="#def-cover-image"></a></h3>
-   <p> A <a data-link-type="dfn" href="#master-image" id="ref-for-master-image②">Master Image</a> that may be used to represent the file contents. An example of this is
-  a single image used to represent an animation before the animation sequence is activated. </p>
-   <h3 class="heading settled" data-level="2.4" id="def-image-collection"><span class="secno">2.4. </span><span class="content"><dfn data-dfn-type="dfn" data-noexport="" id="image-collection">Image Collection<a class="self-link" href="#image-collection"></a></dfn></span><a class="self-link" href="#def-image-collection"></a></h3>
-   <p> One or more <a data-link-type="dfn" href="#master-image" id="ref-for-master-image③">Master Images</a> stored as items in a single file with no defined order or
-  timing information. Within a collection, groups of image samples may share properties and metadata. </p>
-   <h3 class="heading settled" data-level="2.5" id="def-image-properties"><span class="secno">2.5. </span><span class="content"><dfn data-dfn-type="dfn" data-noexport="" id="image-properties">Image Properties<a class="self-link" href="#image-properties"></a></dfn></span><a class="self-link" href="#def-image-properties"></a></h3>
-   <p> This is a class of non-media data. The property items may be descriptive image attribute
-  or decoder configuration data. The properties are primarily for consumption by the decoding
-  agent. This information may include: </p>
-   <ul>
-    <li>decoder specific configuration and initialization values
-    <li>image width and height
-    <li>pixel attributes
-    <li>color space
-   </ul>
-   <h3 class="heading settled" data-level="2.6" id="def-image-sequence"><span class="secno">2.6. </span><span class="content"><dfn data-dfn-type="dfn" data-noexport="" id="image-sequence">Image Sequence<a class="self-link" href="#image-sequence"></a></dfn></span><a class="self-link" href="#def-image-sequence"></a></h3>
-   <p>A sequence of <a data-link-type="dfn" href="#master-image" id="ref-for-master-image④">Master Images</a> stored as a track for which information is provided that defines a sequential ordering and temporal information indicating suggested playback timing. An agent decoding and presenting an AVIF file may chose to render an Image Sequence as an animation. </p>
-   <h3 class="heading settled" data-level="2.7" id="def-master-image"><span class="secno">2.7. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="master-image">Master Image</dfn></span><a class="self-link" href="#def-master-image"></a></h3>
-   <p>An image that is not a thumbnail or auxiliary image. For the purpose of this specification, such an image is encoded using AV1 intra-frame tools. This type of image is the primary displayable payload of an AVIF file. A Master Image may be used as a member of both an Image Collection and an Image Sequence. </p>
-   <h3 class="heading settled" data-level="2.8" id="def-metadata"><span class="secno">2.8. </span><span class="content"><dfn data-dfn-type="dfn" data-noexport="" id="metadata">Metadata<a class="self-link" href="#metadata"></a></dfn></span><a class="self-link" href="#def-metadata"></a></h3>
-   <p>Metadata conveys image attributes that are not used to decode or reconstruct an image. This data is considered to be non-essential and non-normative. Examples of this include EXIF, XMP, and MPEG-7. An AVIF reader will not be required to extract metadata from a Informational Metadata boxes. Essential information shall be carried in the image media directly or be conveyed as Image Properties. </p>
-   <h3 class="heading settled" data-level="2.9" id="def-thumbnail-image"><span class="secno">2.9. </span><span class="content"><dfn data-dfn-type="dfn" data-noexport="" id="thumbnail-image">Thumbnail Image<a class="self-link" href="#thumbnail-image"></a></dfn></span><a class="self-link" href="#def-thumbnail-image"></a></h3>
-   <p>This is a non-master image that may be used to represent one or more <a data-link-type="dfn" href="#master-image" id="ref-for-master-image⑤">Master Images</a> found in an AVIF file. It is typically of a smaller scale than the Master Images. Its compression format may be different than the one used by the Master Images. </p>
-   <h2 class="heading settled" data-level="3" id="object-model-and-structure"><span class="secno">3. </span><span class="content">Object Model and Structure</span><a class="self-link" href="#object-model-and-structure"></a></h2>
-   <p>An AVIF file should be a simplified and conformant version of an <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a> file. This is to allow for the deployment of general libraries that may be used to create and parse HEIF-based image files wrapping different coding methods for the actual image content. This should be similar to ISO-BMFF usage in the video domain. </p>
-   <p>The AVIF file format will be built on the box-structured media interchange format introduced by the ISO Base Media File Format (<a data-link-type="biblio" href="#biblio-isobmff">[ISOBMFF]</a>). The format specified by AVIF defines the use of a subset of box structures introduced in ISOBMFF. Where the necessary structures do not exist in ISOBMFF, structures defined as part of the High Efficiency Image File Format (<a data-link-type="biblio" href="#biblio-heif">[HEIF]</a>: ISO/IEC 23008-12) that are codec neutral and can be applied in a generic manner are used. An AVIF version 1.0 file shall be compliant to the requirements of Clause 4 of the <a data-link-type="biblio" href="#biblio-isobmff">[ISOBMFF]</a> specification, and where applicable, the recommendations in Annex I: Guidelines On Defining New Image Formats and Brands in the MPEG HEIF specification shall be followed for AVIF 1.0. </p>
-   <h3 class="heading settled" data-level="3.1" id="image-storage"><span class="secno">3.1. </span><span class="content">Image Storage</span><a class="self-link" href="#image-storage"></a></h3>
-   <p>All of the constituent elements, including image samples, shall be contained in a single file. All media data locations, regardless of construction method, shall resolve to an offset within an AVIF file. </p>
-   <h3 class="heading settled" data-level="3.2" id="image-collection-elements"><span class="secno">3.2. </span><span class="content">Image Collection Elements</span><a class="self-link" href="#image-collection-elements"></a></h3>
-   <p>An Image Collection is the most basic format of an AVIF file. This form should be used for the case of a single image, or when a group of images that have no logical or temporal sequencing. </p>
-   <p>Image Collections are structured as items defined in a single file-level MetaBox. Each master, thumbnail or auxiliary image that are a component of the Image Collection shall have an item definition in this MetaBox. Items have no timing information. Any association between a Master Image and an Auxiliary or Thumbnail image must be defined explicitly. </p>
-   <p>An AVIF file containing an Image Collection shall list the "mif1" brand as one of the entries in the compatible_brands array and conform to section 10.1 of <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a>. All boxes used to structure a collection are located at the file level within a MetaBox: there are no track level boxes. The image data for a collection may be stored within an ItemDataBox or a MediaDataBox. </p>
-   <p>The images stored in the file are listed in an ItemLocationBox. A unique ItemLocationBox entry shall be used to reference the media data for each image in the collection: Master, Thumbnail and Alpha images. Each image shall have an entry in the ItemLocationBox. </p>
-   <p>The type of the item element is identified in an entry in the ItemInfoBox. Every ItemLocationBox entry shall have a matching entry in the ItemInfoBox cross referenced by the item_ID. </p>
-   <p>The images making up an Image Collection do not need to have the same Image Properties. A specific property may be assigned to one or more of the images within the Image Collection using an ItemPropertyBox entry. </p>
-   <h3 class="heading settled" data-level="3.3" id="image-sequence-elements"><span class="secno">3.3. </span><span class="content">Image Sequence Elements</span><a class="self-link" href="#image-sequence-elements"></a></h3>
-   <p>Image Sequences are structured as tracks. An individual track shall contain one type of image: master, auxiliary or thumbnail. Associations between a thumbnail or auxiliary image, and a master image, is determined by finding components of each track that are time-parallel as defined by procedures detailed in <a data-link-type="biblio" href="#biblio-isobmff">[ISOBMFF]</a>. </p>
-   <p>An AVIF file containing an Image Sequence shall list the "msf1" brand as one of the entries in the compatible_brands array. </p>
-   <p>The timing information provided for a Master Image track is advisory. However, the timing relationship between the master track and any associated non-master track shall be treated strictly when used to determine which images are time-parallel. </p>
-   <p>All Master Images that are part of a sequence shall share the same Image Properties. Any Image Properties assigned to the sequence shall be linked to the track and shall not be linked to an individual image sample. Image Properties are linked to tracks by setting the item_ID field of an ItemPropertyAssociation to a track_id. </p>
-   <p>The determination as to which master track images a non-master image is bound to is made after the decoding sample time is reconstructed for all tracks of the Image Sequence using the TimeToSampleBox (stts) information associated with each track. A non-master image is linked to each master image that has a decode time equal the decode time for that image or falls within the period before the decode time of the next non-master image in the track sequence. </p>
-   <figure>
-     <img alt="Determining time-parallel images between track using decode time." src="images/track_matching.svg"> 
-    <figcaption>Determining time-parallel images between track using decode time</figcaption>
-   </figure>
-   <h3 class="heading settled" data-level="3.4" id="thumbnails"><span class="secno">3.4. </span><span class="content">Thumbnails</span><a class="self-link" href="#thumbnails"></a></h3>
-   <p>For Image Collections, a Thumbnail Image and one or more Master Images shall be linked using an ItemReferenceBox entry with a referenceType of "thmb" in the file-level MetaBox. A single thumbnail may be linked to multiple non-sequential Master Images in the collection. </p>
-   <p>For Image Sequences, a Thumbnail Image track may be associated with the Master Image track. The thumbnail track may contain one or more images. The number of Thumbnail Images shall not exceed the number of Master Images. Presentation timing for the thumbnail track is derived from the track-level TimeToSampleBox and may be treated as advisory for playback. A thumbnail track shall be associated with the primary track using a TrackReferenceBox with a referenceType of "thmb". </p>
-   <h3 class="heading settled" data-level="3.5" id="cover-image①"><span class="secno">3.5. </span><span class="content">Cover Image</span><a class="self-link" href="#cover-image①"></a></h3>
-   <p>A Cover Image differs from a Thumbnail Image in that it is also a Master Image.
-    For Image Collections, a PrimaryItemBox found in the file-level MetaBox may be used to
-    indicate the image item that is to be considered the Cover Image. This image item
-    shall be a master image. If not explicitly indicated in the above manner, the
-    Cover Image shall be assumed to be the first master image entry in the ItemLocationBox. </p>
-   <p>For an Image Sequence, a PrimaryItemBox in a MetaBox found in the TrackBox
-    of the master image track may be used to indicate the Cover Image. The MetaBox
-    containing this PrimaryItemBox shall have a HandlerBox with a hander_type set to "pict"
-    and an ItemLocationBox that has an entry with the same item_ID that is contained
-    in the PrimaryItemBox. The item identified by the item_ID shall a Master Image.
-    If not explicitly indicated in the above manner, the Cover Image shall be assumed
-    to be first entry in the master track. </p>
-   <h3 class="heading settled" data-level="3.6" id="alpha-channel"><span class="secno">3.6. </span><span class="content">Alpha Channel</span><a class="self-link" href="#alpha-channel"></a></h3>
-   <p>An Alpha Image is a specific type of auxiliary image that is used to carry per pixel opacity information for one or more Master Images. This is the only type of Auxiliary Image supported by AVIF. </p>
-   <p>A URN will be defined to identify AVIF alpha auxiliary images or tracks. For the purposes of this draft the placeholder urn:aom:avif:alpha will be used. </p>
-   <p>A brand that represents the encoding format of the alpha image shall be placed in the compatible_brands array of the FileTypeBox. </p>
-   <p>The alpha image shall have the same dimensional attributes as the largest channel plane in the Master Image: width, height, and pixel aspect ratio. Furthermore, the pixels of the Alpha Image shall overlay the pixels of the largest component plane of any linked Master Image exactly. For example, for YUV 4:2:x, this would be the Y component plane. The decoded value of an alpha pixel shall be a normalized unsigned integer of at least 8 bits representing a value between 0.0 and 1.0 or a floating point value between 0.0 and 1.0. </p>
-   <p>For an Image Collection, Alpha Images and Master Images shall be linked using an ItemReferenceBox entry with a reference type of "auxl". A single Alpha Image may be linked to one or more Master Images. The total number of Alpha Images shall not exceed the number of Master Images. When an Alpha Image applies to a subset of the Master Image items this shall constrain all Master Images in that subset to have the same dimensional attributes. </p>
-   <p>When the AVIF file is structured as an Image Sequence, Alpha images may be associated with an Image Sequence using an associated auxiliary track. This track shall have a TrackReferenceBox with a referenceType of "auxl" with an auxiliary type of urn:aom:avif:alpha. For AVIF, only one alpha track may be included in the file. Linking of samples in the Alpha Image track and Master Image track is defined by derived parallel time alignment using each stream’s TimeToSampleBox. The timing relationship between alpha track and primary track is strict and shall not be treated as advisory. At a minimum, the alpha track shall contain a single image. </p>
-   <h3 class="heading settled" data-level="3.7" id="metadata①"><span class="secno">3.7. </span><span class="content">Metadata</span><a class="self-link" href="#metadata①"></a></h3>
-   <p>Metadata is associated through a "cdsc" (content describes) item referenceType element in an ItemReferenceBox for an Image Collection, or a TrackReferenceBox for an Image Sequence. A conforming AVIF reader may ignore all metadata. </p>
-   <h2 class="heading settled" data-level="4" id="file-format"><span class="secno">4. </span><span class="content">File Format</span><a class="self-link" href="#file-format"></a></h2>
-   <h3 class="heading settled" data-level="4.1" id="common-elements"><span class="secno">4.1. </span><span class="content">Common Elements</span><a class="self-link" href="#common-elements"></a></h3>
-   <h4 class="heading settled" data-level="4.1.1" id="file-type-box"><span class="secno">4.1.1. </span><span class="content">FileTypeBox</span><a class="self-link" href="#file-type-box"></a></h4>
-   <p>Each AVIF file will begin with a FileTypeBox. This shall be the first box in the file and may only be preceded by non-ISOBMFF data when necessary. The box should identify this file as conforming to HEIF with specific branding registered for AVIF. </p>
-   <p>If the major_brand field is set to "avif" then the minor_version shall be set to 0. </p>
-   <p>If the major_brand field is not set to "avif", then the brand "avif" shall appear in the compatible_brands array. </p>
+   <h2 class="heading settled" data-level="1" id="general"><span class="secno">1. </span><span class="content">General</span><a class="self-link" href="#general"></a></h2>
+   <p>AVIF is a file format wrapping compressed still images based on the <a href="http://aomedia.org">Alliance for Open Media</a> AV1 intra-frame encoding toolkit.
+AVIF supports High Dynamic Range (HDR) and wide color gamut (WCG) images as well as standard
+dynamic range (SDR). An AVIF file should be a conformant to <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a> for both Image Collections and
+Image Sequences.  An AVIF file shall be compliant to the requirements of Clause 4 of the <a data-link-type="biblio" href="#biblio-isobmff">[ISOBMFF]</a> specification
+and, where applicable, the recommendations in Annex I: Guidelines On Defining New Image Formats
+and Brands in <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a>. </p>
+   <p>For the purposes of this document, the terms, definitions, and abbreviated terms specified in <a data-link-type="biblio" href="#biblio-isobmff">[ISOBMFF]</a> and <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a> apply. </p>
+   <h2 class="heading settled" data-level="2" id="avif=image-collection"><span class="secno">2. </span><span class="content">AVIF Image Collection</span><a class="self-link" href="#avif=image-collection"></a></h2>
+   <h3 class="heading settled" data-level="2.1" id="av1-image-samples"><span class="secno">2.1. </span><span class="content">AV1 Image Data</span><a class="self-link" href="#av1-image-samples"></a></h3>
+   <p>The image item of type "av1i" shall be used for an image collection item coded with AV1. </p>
+   <p> Image items of type "av1i" (AV1 image) are based on AV1 key frames. Specifically the
+  AV1 intra-frame encoding tools as defined by AV1 Bitstream &amp; Decoding Process Specification
+  (<a data-link-type="biblio" href="#biblio-av1-isobmff">[AV1-ISOBMFF]</a>): no intrer-frame encoding shall be permitted between images. The image data
+  is structured as defined by the AV1 Codec ISO Media File Format Binding
+  (<a data-link-type="biblio" href="#biblio-av1">[AV1]</a>) specification.</p>
+   <p>An AVIF file containing an Image Collection shall list the "mif1" brand as one of the entries in
+  the compatible_brands array and conform to sections 6 and 10.2 of <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a>. </p>
+   <h3 class="heading settled" data-level="2.2" id="av1-configuration-item-property"><span class="secno">2.2. </span><span class="content">AV1 Configuration Item Property</span><a class="self-link" href="#av1-configuration-item-property"></a></h3>
+   <p> Each image item of type '"av1i" shall have an associated image property of type "av1C" that is identical
+  to the AV1CodecConfigurationBox as defined in <a data-link-type="biblio" href="#biblio-av1-isobmff">[AV1-ISOBMFF]</a>. Such a property will be marked as essential. </p>
+   <h2 class="heading settled" data-level="3" id="avif-image-sequence"><span class="secno">3. </span><span class="content">AVIF Image Sequence</span><a class="self-link" href="#avif-image-sequence"></a></h2>
+   <h3 class="heading settled" data-level="3.1" id="avif-image-tracks"><span class="secno">3.1. </span><span class="content">AVIF Image Tracks</span><a class="self-link" href="#avif-image-tracks"></a></h3>
+   <p>The sample entry of type "av1i" shall be used for an image sequence track coded with AV1. </p>
+   <p> Image samples of type "av1i" (AV1 image) are based on AV1 key frames. Specifically the
+  AV1 intra-frame encoding tools as defined by AV1 Bitstream &amp; Decoding Process Specification
+  (<a data-link-type="biblio" href="#biblio-av1-isobmff">[AV1-ISOBMFF]</a>): no intrer-frame encoding shall be permitted between images. The image track
+  is structured as defined by the AV1 Codec ISO Media File Format Binding
+  (<a data-link-type="biblio" href="#biblio-av1">[AV1]</a>) specification.</p>
+   <p>An AVIF file containing an Image Sequence shall list the "msf1" brand as one of the entries in the
+  compatible_brands array and conform to sections 7 and 10.3 of <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a>. </p>
+   <h3 class="heading settled" data-level="3.2" id="av1-visual-sample-entryy"><span class="secno">3.2. </span><span class="content">AV1 Visual Sample Entry</span><a class="self-link" href="#av1-visual-sample-entryy"></a></h3>
+   <p> The AV1CodecConfigurationBox as defined in <a data-link-type="biblio" href="#biblio-av1-isobmff">[AV1-ISOBMFF]</a> shall be used as the "av1i" specifi
+  version VisualSampleEntry for the SampleDescriptionBox for all
+ AV1 encoded master image tracks and thumbnail tracks. </p>
+   <h2 class="heading settled" data-level="4" id="alpha-images"><span class="secno">4. </span><span class="content">Alpha Images</span><a class="self-link" href="#alpha-images"></a></h2>
+   <p>An Alpha Image is a specific type of auxiliary image that is used to carry per
+pixel opacity information for one or more Master Images. </p>
+   <p>A URN will be defined to identify AVIF alpha auxiliary images in both collections and sequences. For the
+  purposes of this draft the placeholder urn:aom:avif:alpha will be used whenerver the "auxC" image item property is required. </p>
+   <h2 class="heading settled" data-level="5" id="avif_brands"><span class="secno">5. </span><span class="content">Brands</span><a class="self-link" href="#avif_brands"></a></h2>
+   <p>If the major_brand field is set to "av1i" then the minor_version shall be set to 0. </p>
+   <p>If the major_brand field is not set to "av1i", then the brand "av1i" shall appear in
+the compatible_brands array. </p>
    <p>The compatible_brands array shall contain "mif1" if the file contains an Image Collection. </p>
    <p>The compatible_brands array shall contain "msf1" if the file contains an Image Sequence. </p>
-   <p>The compatible_brands array shall contain an appropriate brand for the encoding used for thumbnails images if it is not AV1. </p>
-   <p>The compatible_brands array shall contain an appropriate brand for the encoding used for alpha images if it is not AV1. </p>
-   <h3 class="heading settled" data-level="4.2" id="collection-elements"><span class="secno">4.2. </span><span class="content">Collection Elements</span><a class="self-link" href="#collection-elements"></a></h3>
-   <p>An AVIF file reader must be able to recognize the following boxes. Any box field or feature not explicitly limited by this specification should be handled as defined in ISO 14496‑12 and ISO 23008-12. </p>
+   <h2 class="heading settled" data-level="6" id="AVIF-version-1.0-profile"><span class="secno">6. </span><span class="content">AVIF Version 1.0 Profile</span><a class="self-link" href="#AVIF-version-1.0-profile"></a></h2>
+   <p>An AVIF verion 1.0 file should be a conformant, simplified version of an <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a> file.
+This is to allow for the deployment of general libraries that may be used to create and parse
+HEIF-based image files wrapping different coding methods for the actual image content.
+  This should be similar to ISO-BMFF usage in the video domain. The following define limitations
+  to the general format of an HEIF file that define the minimum requirements for an AVIF file reader.
+  An implementation of an AVIF file reader may optionally choose to recognise any structure as defined in
+  HEIF. </p>
+   <h3 class="heading settled" data-level="6.1" id="ver1-image-storage"><span class="secno">6.1. </span><span class="content">Image Storage</span><a class="self-link" href="#ver1-image-storage"></a></h3>
+   <p>All of the constituent elements, including image samples, shall be contained in a single
+file. All media data locations, regardless of construction method, shall resolve to an offset
+within an AVIF file. </p>
+   <h3 class="heading settled" data-level="6.2" id="ver1-thumbnails"><span class="secno">6.2. </span><span class="content">Thumbnails</span><a class="self-link" href="#ver1-thumbnails"></a></h3>
+   <p> Only an image type of "av1i" is permited for thumbnails.</p>
+   <h3 class="heading settled" data-level="6.3" id="ver1-cover-image"><span class="secno">6.3. </span><span class="content">Cover Image</span><a class="self-link" href="#ver1-cover-image"></a></h3>
+   <p>A PrimaryItemBox is optional. If a Cover Image is not explicitly indicated by a PrimaryItemBox the
+  Cover Image shall be assumed to be the first master image entry in the ItemLocationBox or the
+  first entry in the master track. </p>
+   <h3 class="heading settled" data-level="6.4" id="ver1-auxiliary-images"><span class="secno">6.4. </span><span class="content">Auxiliary Images</span><a class="self-link" href="#ver1-auxiliary-images"></a></h3>
+   <p> AVIF allows only one type of Auxiliary Image: an Alpha Image. </p>
+   <h3 class="heading settled" data-level="6.5" id="ver1-alpha-channel"><span class="secno">6.5. </span><span class="content">Alpha Channel</span><a class="self-link" href="#ver1-alpha-channel"></a></h3>
+   <p>After applying any transformational Image Properties, the alpha image shall have the same
+  dimensional attributes as the largest channel
+plane in the Master Image: width, height, and pixel aspect ratio. Furthermore, the pixels
+of the Alpha Image shall overlay the pixels of the largest component plane of any linked
+Master Image exactly. For example, for YUV 4:2:x, this would be the Y component plane.
+The decoded value of an alpha pixel shall be a normalized unsigned integer of at least
+8 bits representing a value between 0.0 and 1.0. </p>
+   <h3 class="heading settled" data-level="6.6" id="ver1-sample-groups"><span class="secno">6.6. </span><span class="content">Sample Groups</span><a class="self-link" href="#ver1-sample-groups"></a></h3>
+   <p>Sample groups are not supported for version 1.0 readers. </p>
+   <h3 class="heading settled" data-level="6.7" id="ver1-hidden-images"><span class="secno">6.7. </span><span class="content">Hidden Images</span><a class="self-link" href="#ver1-hidden-images"></a></h3>
+   <p>Hidden images are not supported for version 1.0 readers. </p>
+   <h3 class="heading settled" data-level="6.8" id="ver1-pre-derived-images"><span class="secno">6.8. </span><span class="content">Pre-Derived Coded Images</span><a class="self-link" href="#ver1-pre-derived-images"></a></h3>
+   <p>Pre-derived coded images are not supported for version 1.0 readers. </p>
+   <h3 class="heading settled" data-level="6.9" id="ver1-multi-layer-images"><span class="secno">6.9. </span><span class="content">Multi-Layer Images</span><a class="self-link" href="#ver1-multi-layer-images"></a></h3>
+   <p>Multi-layer images are not supported for version 1.0 readers. This does not limit the
+  underlying image format from encoding multiple layers but this will be internal to the
+  encoded image and managed directly by the decoder and not visible to the AVIF
+  reader. </p>
+   <h3 class="heading settled" data-level="6.10" id="ver1-derived-images"><span class="secno">6.10. </span><span class="content">Derived Images</span><a class="self-link" href="#ver1-derived-images"></a></h3>
+   <p>Derived images are not supported for version 1.0 readers. </p>
+   <h3 class="heading settled" data-level="6.11" id="ver1-metadata"><span class="secno">6.11. </span><span class="content">Metadata</span><a class="self-link" href="#ver1-metadata"></a></h3>
+   <p>Metadata conveys image attributes that are not used to decode or reconstruct an image. This data is
+considered to be non-essential and non-normative. Examples of this include EXIF, XMP, and MPEG-7.
+An AVIF reader will not be required to extract metadata from Informational Metadata boxes. This
+  includes the case of image editing instructions conveyed in an XMP record. Essential
+information shall be carried in the image media directly or be conveyed as Image Properties. </p>
+   <h3 class="heading settled" data-level="6.12" id="collection-elements"><span class="secno">6.12. </span><span class="content">Collection Elements</span><a class="self-link" href="#collection-elements"></a></h3>
+   <p>An AVIF file reader must be able to recognize the following boxes. Any box field or
+feature not explicitly limited by this specification should be handled as defined in
+ISO 14496‑12 and ISO 23008-12. </p>
    <table class="complex data" style="border: 2px solid;">
     <colgroup>
      <col span="3">
@@ -1661,54 +1578,17 @@ pre .property::before, pre .property::after {
       <td>ipma
       <td>0,1
       <td>item property associations
+     <tr>
+      <td>
+      <td>idat
+      <td>
+      <td>-
+      <td>item data box
    </table>
-   <h4 class="heading settled" data-level="4.2.1" id="meta-box"><span class="secno">4.2.1. </span><span class="content">MetaBox</span><a class="self-link" href="#meta-box"></a></h4>
-   <p>A file-level MetaBox shall follow immediately after the FileTypeBox if the file contains an Image Collection. </p>
-   <h4 class="heading settled" data-level="4.2.2" id="handler-box"><span class="secno">4.2.2. </span><span class="content">HandlerBox</span><a class="self-link" href="#handler-box"></a></h4>
-   <p>The handler type for the MetaBox shall be "pict". </p>
-   <h4 class="heading settled" data-level="4.2.3" id="primary-item-box"><span class="secno">4.2.3. </span><span class="content">PrimaryItemBox</span><a class="self-link" href="#primary-item-box"></a></h4>
-   <p>One PrimaryItemBox may be used in this MetaBox to provide a reference to a Cover Image.
-  The image referenced by the PrimaryItemBox shall be a Master Image.
-  The PrimaryItemBox shall come before the ItemLocationBox. </p>
-   <h4 class="heading settled" data-level="4.2.4" id="item-location-box"><span class="secno">4.2.4. </span><span class="content">ItemLocationBox</span><a class="self-link" href="#item-location-box"></a></h4>
-   <p>The data_reference_index for any AVIF conformant element in the ItemLocationBox table entry shall be set to zero. </p>
-   <p>The construction_method value of 2 shall not be used. </p>
-   <h4 class="heading settled" data-level="4.2.5" id="item-properties-box"><span class="secno">4.2.5. </span><span class="content">ItemPropertiesBox</span><a class="self-link" href="#item-properties-box"></a></h4>
-   <p>Item Properties are associated with an item using an ItemPropertiesBox. The type of each property is uniquely identified with a fourCC. Two categories of image properties may be found in an AVIF file. </p>
-   <p>The first catagory are decoder specific configuration and initialization properties. The AVIF codec configuration property will be identified with a property type of "av1C". For non-master image types recommendations may also define codec configuration property formats and usage rules. </p>
-   <p>The second are image descriptive properties conveying the attributes of the encoded image and, by implication, the reconstructed image post decode. The descriptive image properties that may be used in AVIF compliant files are: </p>
-   <ul>
-    <li>Image Spatial Extents (ispe)
-    <li>Pixel Aspect Ratio (pasp)
-    <li>Colour Information (colr)
-    <li>Pixel Information (pixi)
-    <li>Image Rotation (irot)
-    <li>Clean Aperture (clap)
-    <li>Relative Location (rloc)
-    <li>Image Mirroring (imir)
-    <li>Image properties for auxiliary images (auxC)
-   </ul>
-   <h4 class="heading settled" data-level="4.2.6" id="item-info-box"><span class="secno">4.2.6. </span><span class="content">ItemInfoBox</span><a class="self-link" href="#item-info-box"></a></h4>
-   <p>All images samples that are members of the Image Collection shall have an entry in the ItemInfoBox item_infos table. This includes primary, thumbnail, and alpha images </p>
-   <p>Image samples of the collection shall use version 2 or 3 of the ItemInfoEntry box. </p>
-   <p>Each ItemInfoEntry referencing a master image shall have an item_type of "av1i". </p>
-   <p>Each ItemInfoEntry referencing an alpha plane image shall have an item_type field of"uri" and an item_uri_type set to "urn:aom:avif:alpha". </p>
-   <p>Each ItemInfoEntry referencing a thumbnail image shall have an item_type field set to either"av1i" or"jpeg". </p>
-   <p>The item_name is optional. A single byte null string shall be used to indicate an empty item_name. </p>
-   <h4 class="heading settled" data-level="4.2.7" id="item-reference-box"><span class="secno">4.2.7. </span><span class="content">ItemReferenceBox</span><a class="self-link" href="#item-reference-box"></a></h4>
-   <p>An AVIF file reader shall support item references of the following types: </p>
-   <ul>
-    <li>"auxl" auxiliary image; limited to an aux_type of urn:aom:avif:alpha
-    <li>"thmb" thumbnail image; limited to"av1i" or"jpeg"
-   </ul>
-   <p>An AVIF file reader may optionally support item references of the follow type: </p>
-   <ul>
-    <li>"cdsc" content description
-   </ul>
-   <h4 class="heading settled" data-level="4.2.8" id="item-data-box"><span class="secno">4.2.8. </span><span class="content">ItemDataBox</span><a class="self-link" href="#item-data-box"></a></h4>
-   <p>An ItemDataBox shall be used if any ItemLocationBox entry has an"idat" construction method. </p>
-   <h3 class="heading settled" data-level="4.3" id="sequence-elements"><span class="secno">4.3. </span><span class="content">Sequence Elements</span><a class="self-link" href="#sequence-elements"></a></h3>
-   <p>An AVIF file reader must be able recognize the following boxes. Any box field or feature not explicitly limited by this specification should be handled as defined in ISO 14496‑12 and ISO 23008-12. </p>
+   <h3 class="heading settled" data-level="6.13" id="sequence-elements"><span class="secno">6.13. </span><span class="content">Sequence Elements</span><a class="self-link" href="#sequence-elements"></a></h3>
+   <p>An AVIF file reader must be able recognize the following boxes. Any box field or
+feature not explicitly limited by this specification should be handled as defined in
+ISO 14496‑12 and ISO 23008-12. </p>
    <table class="complex data" style="border: 2px solid;">
     <colgroup>
      <col span="4">
@@ -1851,30 +1731,8 @@ pre .property::before, pre .property::after {
       <td>
       <td>
       <td>-
-      <td>
+      <td>media data
    </table>
-   <h4 class="heading settled" data-level="4.3.1" id="movie-box"><span class="secno">4.3.1. </span><span class="content">MovieBox</span><a class="self-link" href="#movie-box"></a></h4>
-   <pthe U0003C="" a="" after="" be="" contained="" directly="" either="" existsU0002C="" file-level="" filetypebox.="" follow="" if="" image="" in="" metaboxU0002C="" moviebox="" moviebox.="" one="" or="" p="" sequence="" shall="" should="" the="" tracks="">
-    <h4 class="heading settled" data-level="4.3.2" id="track-header-box"><span class="secno">4.3.2. </span><span class="content">TrackHeaderBox</span><a class="self-link" href="#track-header-box"></a></h4>
-    <p>For a track of sample type "av1i" the flag field shall be set to track_enabled and track_in_movie. </p>
-    <p>For "thmb" the track_in_preview flag shall be set and track_in_movie cleared. </p>
-    <p>For "auxv" (auxiliary used to convey alpha images) tracks the flag field shall be set to zero. </p>
-    <h4 class="heading settled" data-level="4.3.3" id="track-reference-box"><span class="secno">4.3.3. </span><span class="content">TrackReferenceBox</span><a class="self-link" href="#track-reference-box"></a></h4>
-    <p>The reference_type values supported by an AVIF file shall be: </p>
-    <ul>
-     <li>"thmb"thumbnail track
-     <li>"auxl"; only when the auxiliary track type is alpha
-    </ul>
-    <h4 class="heading settled" data-level="4.3.4" id="media-box"><span class="secno">4.3.4. </span><span class="content">MediaBox</span><a class="self-link" href="#media-box"></a></h4>
-    <p>Each MediaBox associated with AVIF elements "av1i" and "thmb" shall contain a HandlerBox with the handler_type shall be set to "pict". </p>
-    <p>For alpha auxiliary tracks, the handler_type of the HandlerBox shall be "auxv". </p>
-    <h4 class="heading settled" data-level="4.3.5" id="sample-table-box"><span class="secno">4.3.5. </span><span class="content">SampleTableBox</span><a class="self-link" href="#sample-table-box"></a></h4>
-    <p>The "av1i" codec configuration (see ItemPropertyBox above) block shall be used as the AV1 specific version of the SampleDescriptionBox for all AV1 encoded image tracks: primary and AV1 encoded thumbnail images. </p>
-    <p>A JPEG encoded thumbnail shall conform to section H of the HEIF specification and use the "jpgC" JpegConfigurationBox as its sample descriptor. </p>
-    <p>For an alpha track, the AuxiliaryTypeInfoBox shall be used as SampleDescriptionBox entry in the SampleTableBox for an alpha track. The aux_track_type shall be assigned the string urn:aom:avif:alpha. This is the only type of auxiliary track defined by this specification. </p>
-    <h4 class="heading settled" data-level="4.3.6" id="data-reference-box"><span class="secno">4.3.6. </span><span class="content">DataReferenceBox</span><a class="self-link" href="#data-reference-box"></a></h4>
-    <p>Only one type of DataReferenceBox table entry shall be used to define to the location of an AVIF media data element: the DataEntryUrlBox. Furthermore, the entry_flag must be set to 0x001 to signal that the data element resides in the same file as the containing DataReferenceBox. </p>
-   </pthe>
   </main>
   <div data-fill-with="conformance">
    <h2 class="no-ref no-num heading settled" id="conformance"><span class="content"> Conformance</span><a class="self-link" href="#conformance"></a></h2>
@@ -2022,107 +1880,17 @@ pre .property::before, pre .property::after {
 
 })();
 </script>
-  <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
-  <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
-  <ul class="index">
-   <li><a href="#alpha-image">Alpha Image</a><span>, in §2.1</span>
-   <li><a href="#auxiliary-image">Auxiliary Image</a><span>, in §2.2</span>
-   <li><a href="#cover-image">Cover Image</a><span>, in §2.3</span>
-   <li><a href="#image-collection">Image Collection</a><span>, in §2.4</span>
-   <li><a href="#image-properties">Image Properties</a><span>, in §2.5</span>
-   <li><a href="#image-sequence">Image Sequence</a><span>, in §2.6</span>
-   <li><a href="#master-image">Master Image</a><span>, in §2.7</span>
-   <li><a href="#metadata">Metadata</a><span>, in §2.8</span>
-   <li><a href="#thumbnail-image">Thumbnail Image</a><span>, in §2.9</span>
-  </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
    <dt id="biblio-av1">[AV1]
    <dd><a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.html">AV1 Bitstream &amp; Decoding Process Specification</a>. LS. URL: <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.html">http://av1-spec.argondesign.com/av1-spec/av1-spec.html</a>
+   <dt id="biblio-av1-isobmff">[AV1-ISOBMFF]
+   <dd><a href="https://aomediacodec.github.io/av1-isobmff/">AV1 Codec ISO Media File Format Binding</a>. LS. URL: <a href="https://aomediacodec.github.io/av1-isobmff/">https://aomediacodec.github.io/av1-isobmff/</a>
    <dt id="biblio-heif">[HEIF]
-   <dd><a href="https://www.iso.org/standard/66067.html">Information technology — High efficiency coding and media delivery in heterogeneous environments — Part 12: Image File Format</a>. December 2017. International Standard. URL: <a href="https://www.iso.org/standard/66067.html">https://www.iso.org/standard/66067.html</a>
+   <dd><a href="https://www.iso.org/standard/66067.html">Information technology — High efficiency coding and media delivery in heterogeneous environments — Part 12: Image File Format</a>. International Standard. URL: <a href="https://www.iso.org/standard/66067.html">https://www.iso.org/standard/66067.html</a>
    <dt id="biblio-isobmff">[ISOBMFF]
    <dd><a href="http://standards.iso.org/ittf/PubliclyAvailableStandards/c068960_ISO_IEC_14496-12_2015.zip">Information technology — Coding of audio-visual objects — Part 12: ISO Base Media File Format</a>. December 2015. International Standard. URL: <a href="http://standards.iso.org/ittf/PubliclyAvailableStandards/c068960_ISO_IEC_14496-12_2015.zip">http://standards.iso.org/ittf/PubliclyAvailableStandards/c068960_ISO_IEC_14496-12_2015.zip</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
   </dl>
-  <aside class="dfn-panel" data-for="alpha-image">
-   <b><a href="#alpha-image">#alpha-image</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-alpha-image">2.2. Auxiliary Image</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="auxiliary-image">
-   <b><a href="#auxiliary-image">#auxiliary-image</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-auxiliary-image">2.1. Alpha Image</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="master-image">
-   <b><a href="#master-image">#master-image</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-master-image">2.1. Alpha Image</a>
-    <li><a href="#ref-for-master-image①">2.2. Auxiliary Image</a>
-    <li><a href="#ref-for-master-image②">2.3. Cover Image</a>
-    <li><a href="#ref-for-master-image③">2.4. Image Collection</a>
-    <li><a href="#ref-for-master-image④">2.6. Image Sequence</a>
-    <li><a href="#ref-for-master-image⑤">2.9. Thumbnail Image</a>
-   </ul>
-  </aside>
-<script>/* script-dfn-panel */
-
-        document.body.addEventListener("click", function(e) {
-            var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-            // Find the dfn element or panel, if any, that was clicked on.
-            var el = e.target;
-            var target;
-            var hitALink = false;
-            while(el.parentElement) {
-                if(el.tagName == "A") {
-                    // Clicking on a link in a <dfn> shouldn't summon the panel
-                    hitALink = true;
-                }
-                if(el.classList.contains("dfn-paneled")) {
-                    target = "dfn";
-                    break;
-                }
-                if(el.classList.contains("dfn-panel")) {
-                    target = "dfn-panel";
-                    break;
-                }
-                el = el.parentElement;
-            }
-            if(target != "dfn-panel") {
-                // Turn off any currently "on" or "activated" panels.
-                queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-                    el.classList.remove("on");
-                    el.classList.remove("activated");
-                });
-            }
-            if(target == "dfn" && !hitALink) {
-                // open the panel
-                var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-                if(dfnPanel) {
-                    dfnPanel.classList.add("on");
-                    var rect = el.getBoundingClientRect();
-                    dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-                    dfnPanel.style.top = window.scrollY + rect.top + "px";
-                    var panelRect = dfnPanel.getBoundingClientRect();
-                    var panelWidth = panelRect.right - panelRect.left;
-                    if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                        // Reposition, because the panel is overflowing
-                        dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-                    }
-                } else {
-                    console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-                }
-            } else if(target == "dfn-panel") {
-                // Switch it to "activated" state, which pins it.
-                el.classList.add("activated");
-                el.style.left = null;
-                el.style.top = null;
-            }
-
-        });
-        </script>

--- a/index.bs
+++ b/index.bs
@@ -1,15 +1,16 @@
+
 <pre class='metadata'>
-Title: AV1 Still Image File Format (AVIF)
+Title: AV1 Image File Format (AVIF)
 Shortname: av1-avif
 Level: 1
-Date: 2018-05-09
+Date: 2018-06-03
 Status: LS
 Group: AOM
 URL: https://AOMediaCodec.github.io/av1-avif
 Repository: AOMediaCodec/av1-avif
 Inline Github Issues: full
 Editor: Paul Kerr, Netflix, pkerr@netflix.com
-Abstract: This document contains a set of requirements that can be used to contain a one or more [[!AV1]] still images in a file using structures defined by the a [[!ISOBMFF]] and [[!HEIF]] specifications meant to allow for a mimumum set of features to allow the interchange of files between AVIF writers and readers. The file format described here conforms to the interoperability rules as defined in MIAF as applied to the structures used within this specification. AVIF respresents a functional subset of the features and attributes defined in the codec agnostic sections of HEIF. 
+Abstract: This document contains a set of requirements that can be used to incorporate one or more [[!AV1]] still images in a file using structures and procedures defined by the [[!HEIF]] specification. This specification defines a set of minimum requirements to allow the interchange of files between AVIF writers and readers. 
 Boilerplate: copyright yes
 Warning: Custom
 Custom Warning Title: Warning
@@ -36,274 +37,166 @@ THE OTHER MEMBER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <pre class="anchors">
 </pre>
 
-<h2 id="overview">Overview</h2>
+<h2 id="general">General</h2>
 
-<p>AVIF is a file format wrapping compressed images based on the
+<p>AVIF is a file format wrapping compressed still images based on the
 <a href="http://aomedia.org">Alliance for Open Media</a> AV1 intra-frame encoding toolkit.
 AVIF supports High Dynamic Range (HDR) and wide color gamut (WCG) images as well as standard
-dynamic range (SDR). Only the intra-frame encoding toolkit is used in AVIF version 1.0. Using
-the intra-frame encoding mechanism from an existing video codec standard has a precedent in WebP:
-VP8, and HEIF: HEVC. This document describes at a high level a proposal on the structure of AVIF version 1.0.
+dynamic range (SDR). An AVIF file should be a conformant to [[!HEIF]] for both Image Collections and
+Image Sequences.  An AVIF file shall be compliant to the requirements of Clause 4 of the [[!ISOBMFF]] specification
+and, where applicable, the recommendations in Annex I: Guidelines On Defining New Image Formats
+and Brands in [[!HEIF]].
+</p>
+<p>For the purposes of this document, the terms, definitions, and abbreviated terms specified in [[!ISOBMFF]] and [[!HEIF]] apply.
 </p>
 
-<p>The initial version of AVIF seeks to be simple, with just enough structure to allow the distribution
-of images based on the AV1 intra-frame coding toolset. At its core, AVIF 1.0 will allow for one or more
-images plus all supporting data needed to correctly reconstruct and display the images to be conveyed
-in a file. The ability to embed a thumbnail image will also be provided. An image sequence with suggested
-playback timing may be defined.
-</p>
+<h2 id="avif=image-collection">AVIF Image Collection</h2>
 
-<h3 id="target-features">Target Features</h3>
-<ul>
-  <li>AV1 intra-frame codec toolkit</li>
-  <li>Multiple image storage: untimed unordered collection</li>
-  <li>Animation: timed sequence of images</li>
-  <li>Thumbnail image</li>
-  <li>Alpha channel</li>
-  <li>Extensible image metadata</li>
-</ul>
+<h3 id="av1-image-samples">AV1 Image Data</h2>
 
-<h2 id="terms-and-definitions">Terms and Definitions</h2>
+<p>The image item of type "av1i" shall be used for an image collection item coded with AV1.
 
-<h3 id="def-alpha-image"><dfn>Alpha Image</dfn></h3>
-<p>A specific type of [=Auxiliary Image=] that may be used to convey information representing
-the opacity of associated [=Master Images=].
-</p>
+<p> Image items of type "av1i" (AV1 image) are based on AV1 key frames. Specifically the
+  AV1 intra-frame encoding tools as defined by AV1 Bitstream & Decoding Process Specification
+  ([[!AV1-ISOBMFF]]): no intrer-frame encoding shall be permitted between images. The image data
+  is structured as defined by the AV1 Codec ISO Media File Format Binding
+  ([[!AV1]]) specification.</p>
 
-<h3 id="def-auxiliary-image"><dfn>Auxiliary Image</dfn></h3>
-<p>An image that is not be intended to be displayed but provides supplemental information for
-associated [=Master Images=]. AVIF allows only one type of Auxiliary Image: an [=Alpha Image=].
-</p>
-
-<h3 id="def-cover-image"><dfn>Cover Image</dfn></h3>
-<p>A [=Master Image=] that may be used to represent the file contents. An example of this is
-a single image used to represent an animation before the animation sequence is activated.
-</p>
-
-<h3 id="def-image-collection"><dfn>Image Collection</dfn></h3>
-<p>One or more [=Master Images=] stored as items in a single file with no defined order or
-timing information. Within a collection, groups of image samples may share properties and metadata.
-</p>
-
-<h3 id="def-image-properties"><dfn>Image Properties</dfn></h3>
-<p>This is a class of non-media data. The property items may be descriptive image attribute
-or decoder configuration data. The properties are primarily for consumption by the decoding
-agent. This information may include:
-</p>
-
-<ul>
-  <li>decoder specific configuration and initialization values</li>
-  <li>image width and height</li>
-  <li>pixel attributes</li>
-  <li>color space</li>
-</ul>
-
-<h3 id="def-image-sequence"><dfn>Image Sequence</dfn></h3>
-
-<p>A sequence of [=Master Images=] stored as a track for which information is provided that defines a
-sequential ordering and temporal information indicating suggested playback timing. An agent decoding
-and presenting an AVIF file may chose to render an Image Sequence as an animation.
-</p>
-
-<h3 id="def-master-image"><dfn>Master Image</dfn></h3>
-
-<p>An image that is not a thumbnail or auxiliary image. For the purpose of this specification,
-such an image is encoded using AV1 intra-frame tools. This type of image is the primary displayable
-payload of an AVIF file. A Master Image may be used as a member of both an Image Collection and an
-Image Sequence.
-</p>
-
-<h3 id="def-metadata"><dfn>Metadata</dfn></h3>
-
-<p>Metadata conveys image attributes that are not used to decode or reconstruct an image. This data is
-considered to be non-essential and non-normative. Examples of this include EXIF, XMP, and MPEG-7.
-An AVIF reader will not be required to extract metadata from a Informational Metadata boxes. Essential
-information shall be carried in the image media directly or be conveyed as Image Properties.
-</p>
-
-<h3 id="def-thumbnail-image"><dfn>Thumbnail Image</dfn></h3>
-
-<p>This is a non-master image that may be used to represent one or more [=Master Images=] found in an
-AVIF file. It is typically of a smaller scale than the Master Images. Its compression format may be
-different than the one used by theMaster Images.
-</p>
-
-<h2 id="object-model-and-structure">Object Model and Structure</h2>
-
-<p>An AVIF file should be a simplified and conformant version of an [[!HEIF]] file.
-This is to allow for the deployment of general libraries that may be used to create and parse
-HEIF-based image files wrapping different coding methods for the actual image content.
-This should be similar to ISO-BMFF usage in the video domain.
-</p>
-<p>
-The AVIF file format will be built on the box-structured media interchange format introduced
-by the ISO Base Media File Format ([[!ISOBMFF]]). The format specified by AVIF defines the use
-of a subset of box structures introduced in ISOBMFF. Where the necessary structures do not
-exist in ISOBMFF, structures defined as part of the High Efficiency Image File Format
-([[!HEIF]]: ISO/IEC 23008-12) that are codec neutral and can be applied in a generic manner
-are used. An AVIF version 1.0 file shall be compliant to the requirements of Clause 4 of the
-[[!ISOBMFF]] specification, and where applicable, the recommendations in Annex I: Guidelines
-On Defining New Image Formats and Brands in the MPEG HEIF specification shall be followed
-for AVIF 1.0.
-</p>
-
-<h3 id="image-storage">Image Storage</h3>
-
-<p>All of the constituent elements, including image samples, shall be contained in a single
-file. All media data locations, regardless of construction method, shall resolve to an offset
-within an AVIF file.
-</p>
-
-<h3 id="image-collection-elements">Image Collection Elements</h3>
-
-<p>An Image Collection is the most basic format of an AVIF file. This form should be used for
-the case of a single image, or when a group of images that have no logical or temporal sequencing.
-</p>
-<p>Image Collections are structured as items defined in a single file-level MetaBox. Each master,
-thumbnail or auxiliary image that are a component of the Image Collection shall have an item definition
-in this MetaBox. Items have no timing information. Any association between a Master Image and
-an Auxiliary or Thumbnail image must be defined explicitly.
-</p>
 <p>An AVIF file containing an Image Collection shall list the "mif1" brand as one of the entries in
-the compatible_brands array and conform to section 10.1 of [[!HEIF]]. All boxes used to structure
-a collection are located at the file level within a MetaBox: there are no track level boxes.
-The image data for a collection may be stored within an ItemDataBox or a MediaDataBox.
-</p>
-<p>The images stored in the file are listed in an ItemLocationBox. A unique ItemLocationBox entry
-shall be used to reference the media data for each image in the collection: Master, Thumbnail
-and Alpha images. Each image shall have an entry in the ItemLocationBox.
-</p>
-<p>The type of the item element is identified in an entry in the ItemInfoBox. Every ItemLocationBox
-entry shall have a matching entry in the ItemInfoBox cross referenced by the item_ID.
-</p>
-<p>The images making up an Image Collection do not need to have the same Image Properties.
-A specific property may be assigned to one or more of the images within the Image Collection
-using an ItemPropertyBox entry.
+  the compatible_brands array and conform to sections 6 and 10.2 of [[!HEIF]].
 </p>
 
-<h3 id="image-sequence-elements">Image Sequence Elements</h3>
+<h3 id="av1-configuration-item-property">AV1 Configuration Item Property</h3>
 
-<p>Image Sequences are structured as tracks. An individual track shall contain one type of image:
-master, auxiliary or thumbnail. Associations between a thumbnail or auxiliary image, and a master
-image, is determined by finding components of each track that are time-parallel as defined by procedures
-detailed in [[!ISOBMFF]].
+<p> Each image item of type '"av1i" shall have an associated image property of type "av1C" that is identical
+  to the AV1CodecConfigurationBox as defined in [[!AV1-ISOBMFF]]. Such a property will be marked as essential.
 </p>
+
+
+<h2 id="avif-image-sequence">AVIF Image Sequence</h2>
+
+<h3 id="avif-image-tracks">AVIF Image Tracks</h3>
+
+<p>The sample entry of type "av1i" shall be used for an image sequence track coded with AV1.
+
+<p> Image samples of type "av1i" (AV1 image) are based on AV1 key frames. Specifically the
+  AV1 intra-frame encoding tools as defined by AV1 Bitstream & Decoding Process Specification
+  ([[!AV1-ISOBMFF]]): no intrer-frame encoding shall be permitted between images. The image track
+  is structured as defined by the AV1 Codec ISO Media File Format Binding
+  ([[!AV1]]) specification.</p>
+
 <p>An AVIF file containing an Image Sequence shall list the "msf1" brand as one of the entries in the
-compatible_brands array.
-</p>
-<p>The timing information provided for a Master Image track is advisory. However, the timing
-relationship between the master track and any associated non-master track shall be treated strictly
-when used to determine which images are time-parallel.
-</p>
-<p>All Master Images that are part of a sequence shall share the same Image Properties. Any Image
-Properties assigned to the sequence shall be linked to the track and shall not be linked to an
-individual image sample. Image Properties are linked to tracks by setting the item_ID field of
-an ItemPropertyAssociation to a track_id.
-</p>
-<p>The determination as to which master track images a non-master image is bound to is made after
-the decoding sample time is reconstructed for all tracks of the Image Sequence using the TimeToSampleBox
-(stts) information associated with each track. A non-master image is linked to each master image that
-has a decode time equal the decode time for that image or falls within the period before the decode time
-of the next non-master image in the track sequence.
+  compatible_brands array and conform to sections 7 and 10.3 of [[!HEIF]].
 </p>
 
-<figure>
-  <img alt="Determining time-parallel images between track using decode time." src="images/track_matching.svg">
-  <figcaption>Determining time-parallel images between track using decode time</figcaption>
-</figure>
+<h3 id="av1-visual-sample-entryy">AV1 Visual Sample Entry</h3>
 
-<h3 id="thumbnails">Thumbnails</h3>
+<p> The AV1CodecConfigurationBox as defined in [[!AV1-ISOBMFF]] shall be used as the "av1i" specifi
+  version VisualSampleEntry for the SampleDescriptionBox for all
+ AV1 encoded master image tracks and thumbnail tracks.
+ </p>
 
-<p>For Image Collections, a Thumbnail Image and one or more Master Images shall be linked using an
-ItemReferenceBox entry with a referenceType of "thmb" in the file-level MetaBox. A single thumbnail
-may be linked to multiple non-sequential Master Images in the collection.
-</p>
-<p>For Image Sequences, a Thumbnail Image track may be associated with the Master Image track.
-The thumbnail track may contain one or more images. The number of Thumbnail Images shall not exceed
-the number of Master Images. Presentation timing for the thumbnail track is derived from the track-level
-TimeToSampleBox and may be treated as advisory for playback. A thumbnail track shall be associated with
-the primary track using a TrackReferenceBox with a referenceType of "thmb".
-</p>
+<h2 id="alpha-images">Alpha Images</h2>
 
-<h3 id="cover-image">Cover Image</h3>
-
-<p>A Cover Image differs from a Thumbnail Image in that it is also a Master Image.
-For Image Collections, a PrimaryItemBox found in the file-level MetaBox may be used to
-indicate the image item that is to be considered the Cover Image. This image item
-shall be a master image. If not explicitly indicated in the above manner, the
-Cover Image shall be assumed to be the first master image entry in the ItemLocationBox.
-</p>
-<p>For an Image Sequence, a PrimaryItemBox in a MetaBox found in the TrackBox
-of the master image track may be used to indicate the Cover Image. The MetaBox
-containing this PrimaryItemBox shall have a HandlerBox with a hander_type set to "pict"
-and an ItemLocationBox that has an entry with the same item_ID that is contained
-in the PrimaryItemBox. The item identified by the item_ID shall a Master Image.
-If not explicitly indicated in the above manner, the Cover Image shall be assumed
-to be first entry in the master track.
-</p>
-
-<h3 id="alpha-channel">Alpha Channel</h3>
 <p>An Alpha Image is a specific type of auxiliary image that is used to carry per
-pixel opacity information for one or more Master Images. This is the only type of
-Auxiliary Image supported by AVIF.
+pixel opacity information for one or more Master Images.
 </p>
-<p>A URN will be defined to identify AVIF alpha auxiliary images or tracks. For the
-purposes of this draft the placeholder urn:aom:avif:alpha will be used.
-</p>
-<p>A brand that represents the encoding format of the alpha image shall be placed in
-the compatible_brands array of the FileTypeBox.
-</p>
-<p>The alpha image shall have the same dimensional attributes as the largest channel
-plane in the Master Image: width, height, and pixel aspect ratio. Furthermore, the pixels
-of the Alpha Image shall overlay the pixels of the largest component plane of any linked
-Master Image exactly. For example, for YUV 4:2:x, this would be the Y component plane.
-The decoded value of an alpha pixel shall be a normalized unsigned integer of at least
-8 bits representing a value between 0.0 and 1.0 or a floating point value between 0.0 and 1.0.
-</p>
-<p>For an Image Collection, Alpha Images and Master Images shall be linked using an
-ItemReferenceBox entry with a reference type of "auxl". A single Alpha Image may be linked
-to one or more Master Images. The total number of Alpha Images shall not exceed the number
-of Master Images. When an Alpha Image applies to a subset of the Master Image items this
-shall constrain all Master Images in that subset to have the same dimensional attributes.
-</p>
-<p>When the AVIF file is structured as an Image Sequence, Alpha images may be associated
-with an Image Sequence using an associated auxiliary track. This track shall have a TrackReferenceBox
-with a referenceType of "auxl" with an auxiliary type of urn:aom:avif:alpha. For AVIF, only
-one alpha track may be included in the file. Linking of samples in the Alpha Image track
-and Master Image track is defined by derived parallel time alignment using each stream's
-TimeToSampleBox. The timing relationship between alpha track and primary track is strict
-and shall not be treated as advisory. At a minimum, the alpha track shall contain a single image.
+<p>A URN will be defined to identify AVIF alpha auxiliary images in both collections and sequences. For the
+  purposes of this draft the placeholder urn:aom:avif:alpha will be used whenerver the "auxC" image item property is required.
 </p>
 
-<h3 id="metadata">Metadata</h3>
+<h2 id="avif_brands">Brands</h2>
 
-<p>Metadata is associated through a "cdsc" (content describes) item referenceType element
-in an ItemReferenceBox for an Image Collection, or a TrackReferenceBox for an Image Sequence.
-A conforming AVIF reader may ignore all metadata.
+<p>If the major_brand field is set to "av1i" then the minor_version shall be set to 0.
 </p>
-
-<h2 id="file-format">File Format</h2>
-<h3 id="common-elements">Common Elements</h3>
-<h4 id="file-type-box">FileTypeBox</h4>
-
-<p>Each AVIF file will begin with a FileTypeBox. This shall be the first box in the file
-and may only be preceded by non-ISOBMFF data when necessary. The box should identify this
-file as conforming to HEIF with specific branding registered for AVIF.
-</p>
-<p>If the major_brand field is set to "avif" then the minor_version shall be set to 0.
-</p>
-<p>If the major_brand field is not set to "avif", then the brand "avif" shall appear in
+<p>If the major_brand field is not set to "av1i", then the brand "av1i" shall appear in
 the compatible_brands array.
 </p>
 <p>The compatible_brands array shall contain "mif1" if the file contains an Image Collection.
 </p>
 <p>The compatible_brands array shall contain "msf1" if the file contains an Image Sequence.
 </p>
-<p>The compatible_brands array shall contain an appropriate brand for the encoding used
-for thumbnails images if it is not AV1.
+
+<h2 id="AVIF-version-1.0-profile">AVIF Version 1.0 Profile</h2>
+
+<p>An AVIF verion 1.0 file should be a conformant, simplified version of an [[!HEIF]] file.
+This is to allow for the deployment of general libraries that may be used to create and parse
+HEIF-based image files wrapping different coding methods for the actual image content.
+  This should be similar to ISO-BMFF usage in the video domain. The following define limitations
+  to the general format of an HEIF file that define the minimum requirements for an AVIF file reader.
+  An implementation of an AVIF file reader may optionally choose to recognise any structure as defined in
+  HEIF.
 </p>
-<p>The compatible_brands array shall contain an appropriate brand for the encoding used
-for alpha images if it is not AV1.
+
+<h3 id="ver1-image-storage">Image Storage</h3>
+
+<p>All of the constituent elements, including image samples, shall be contained in a single
+file. All media data locations, regardless of construction method, shall resolve to an offset
+within an AVIF file.
+</p>
+
+<h3 id="ver1-thumbnails">Thumbnails</h3>
+
+<p> Only an image type of "av1i" is permited for thumbnails.</p>
+
+<h3 id="ver1-cover-image">Cover Image</h3>
+
+<p>A PrimaryItemBox is optional. If a Cover Image is not explicitly indicated by a PrimaryItemBox the
+  Cover Image shall be assumed to be the first master image entry in the ItemLocationBox or the
+  first entry in the master track.
+</p>
+
+<h3 id="ver1-auxiliary-images">Auxiliary Images</h3>
+
+<p> AVIF allows only one type of Auxiliary Image: an Alpha Image.
+</p>
+
+<h3 id="ver1-alpha-channel">Alpha Channel</h3>
+
+<p>After applying any transformational Image Properties, the alpha image shall have the same
+  dimensional attributes as the largest channel
+plane in the Master Image: width, height, and pixel aspect ratio. Furthermore, the pixels
+of the Alpha Image shall overlay the pixels of the largest component plane of any linked
+Master Image exactly. For example, for YUV 4:2:x, this would be the Y component plane.
+The decoded value of an alpha pixel shall be a normalized unsigned integer of at least
+8 bits representing a value between 0.0 and 1.0.
+</p>
+
+<h3 id="ver1-sample-groups">Sample Groups</h3>
+
+<p>Sample groups are not supported for version 1.0 readers.
+</p>
+
+<h3 id="ver1-hidden-images">Hidden Images</h3>
+
+<p>Hidden images are not supported for version 1.0 readers.
+</p>
+
+<h3 id="ver1-pre-derived-images">Pre-Derived Coded Images</h3>
+
+<p>Pre-derived coded images are not supported for version 1.0 readers.
+</p>
+
+<h3 id="ver1-multi-layer-images">Multi-Layer Images</h3>
+
+<p>Multi-layer images are not supported for version 1.0 readers. This does not limit the
+  underlying image format from encoding multiple layers but this will be internal to the
+  encoded image and managed directly by the decoder and not visible to the AVIF
+  reader.
+</p>
+
+<h3 id="ver1-derived-images">Derived Images</h3>
+
+<p>Derived images are not supported for version 1.0 readers.
+</p>
+
+<h3 id="ver1-metadata">Metadata</h3>
+
+<p>Metadata conveys image attributes that are not used to decode or reconstruct an image. This data is
+considered to be non-essential and non-normative. Examples of this include EXIF, XMP, and MPEG-7.
+An AVIF reader will not be required to extract metadata from Informational Metadata boxes. This
+  includes the case of image editing instructions conveyed in an XMP record. Essential
+information shall be carried in the image media directly or be conveyed as Image Properties.
 </p>
 
 <h3 id="collection-elements">Collection Elements</h3>
@@ -396,101 +289,17 @@ ISO 14496&#8209;12 and ISO 23008-12.
       <td>0,1</td>
       <td>item property associations</td>
     </tr>
+    </tr>
+    <tr>
+      <td></td>
+      <td>idat</td>
+      <td></td>
+      <td>-</td>
+      <td>item data box</td>
+    </tr>
   </tbody>
 </table>
 
-<h4 id="meta-box">MetaBox</h4>
-<p>A file-level MetaBox shall follow immediately after the FileTypeBox if the file contains an Image Collection.
- </p>
-
-<h4 id="handler-box">HandlerBox</h4>
-
-<p>The handler type for the MetaBox shall be "pict".
-</p>
-
-<h4 id="primary-item-box">PrimaryItemBox</h4>
-
-<p>One PrimaryItemBox may be used in this MetaBox to provide a reference to a Cover Image.
-The image referenced by the PrimaryItemBox shall be a Master Image.
-The PrimaryItemBox shall come before the ItemLocationBox.
-</p>
-
-<h4 id="item-location-box">ItemLocationBox</h4>
-
-<p>The data_reference_index for any AVIF conformant element in the ItemLocationBox
-table entry shall be set to zero.
-</p>
-<p>The construction_method value of 2 shall not be used.
-</p>
-
-<h4 id="item-properties-box">ItemPropertiesBox</h4>
-
-<p>Item Properties are associated with an item using an ItemPropertiesBox.
-The type of each property is uniquely identified with a fourCC. Two categories
-of image properties may be found in an AVIF file.
-</p>
-<p>The first catagory are decoder specific configuration and initialization properties.
-The AVIF codec configuration property will be identified with a property type of "av1C".
-For non-master image types recommendations may also define codec configuration property
-formats and usage rules.
-</p>
-<p>The second are image descriptive properties conveying the attributes of the encoded
-image and, by implication, the reconstructed image post decode. The descriptive image
-properties that may be used in AVIF compliant files are:
-</p>
-
-<ul>
-  <li>Image Spatial Extents (ispe)</li>
-  <li>Pixel Aspect Ratio (pasp)</li>
-  <li>Colour Information (colr)</li>
-  <li>Pixel Information (pixi)</li>
-  <li>Image Rotation (irot)</li>
-  <li>Clean Aperture (clap)</li>
-  <li>Relative Location (rloc)</li>
-  <li>Image Mirroring (imir)</li>
-  <li>Image properties for auxiliary images (auxC)</li>
-</ul>
-
-<h4 id="item-info-box">ItemInfoBox</h4>
-
-<p>All images samples that are members of the Image Collection shall have an entry
-in the ItemInfoBox item_infos table. This includes primary, thumbnail, and alpha images
-</p>
-<p>Image samples of the collection shall use version 2 or 3 of the ItemInfoEntry box.
-</p>
-<p>Each ItemInfoEntry referencing a master image shall have an item_type of "av1i".
-</p>
-<p>Each ItemInfoEntry referencing an alpha plane image shall have an item_type field
-of"uri" and an item_uri_type set to "urn:aom:avif:alpha".
-</p>
-<p>Each ItemInfoEntry referencing a thumbnail image shall have an item_type field set
-to either"av1i" or"jpeg".
-</p>
-<p>The item_name is optional. A single byte null string shall be used to indicate
-an empty item_name.
-</p>
-
-<h4 id="item-reference-box">ItemReferenceBox</h4>
-
-<p>An AVIF file reader shall support item references of the following types:
-</p>
-
-<ul>
-  <li>"auxl" auxiliary image; limited to an aux_type of urn:aom:avif:alpha</li>
-  <li>"thmb" thumbnail image; limited to"av1i" or"jpeg"</li>
-</ul>
-
-<p>An AVIF file reader may optionally support item references of the follow type:
-</p>
-
-<ul>
-  <li>"cdsc" content description</li>
-</ul>
-
-<h4 id="item-data-box">ItemDataBox</h4>
-
-<p>An ItemDataBox shall be used if any ItemLocationBox entry has an"idat" construction method.
-</p>
 
 <h3 id="sequence-elements">Sequence Elements</h3>
 
@@ -662,66 +471,9 @@ ISO 14496&#8209;12 and ISO 23008-12.
       <td></td>
       <td></td>
       <td>-</td>
-      <td></td>
+      <td>media data</td>
     </tr>
   </tbody>
 </table>
-
-<h4 id="movie-box">MovieBox</h4>
-
-<p>The Image Sequence tracks shall be contained in a MovieBox. The
- MovieBox should follow directly after either a file-level MetaBox, if one exists,
- or the FileTypeBox.
-</p>
-
-<h4 id="track-header-box">TrackHeaderBox</h4>
-
-<p>For a track of sample type "av1i" the flag field shall be set to track_enabled and track_in_movie.
-</p>
-<p>For "thmb" the track_in_preview flag shall be set and track_in_movie cleared.
-</p>
-<p>For "auxv" (auxiliary used to convey alpha images) tracks the flag field shall be set to zero.
-</p>
-
-<h4 id="track-reference-box">TrackReferenceBox</h4>
-<p>The reference_type values supported by an AVIF file shall be:
-</p>
-
-<ul>
-  <li>"thmb"thumbnail track</li>
-  <li>"auxl"; only when the auxiliary track type is alpha</li>
-</ul>
-
-<h4 id="media-box">MediaBox</h4>
-
-<p>Each MediaBox associated with AVIF elements "av1i" and "thmb" shall
-  contain a HandlerBox
-  with the handler_type shall be set to "pict".
-</p>
-<p>For alpha auxiliary tracks, the handler_type of the HandlerBox shall be "auxv".
-</p>
-
-<h4 id="sample-table-box">SampleTableBox</h4>
-<p>The "av1i" codec configuration (see ItemPropertyBox above) block
-    shall be used as the AV1 specific version of the SampleDescriptionBox for all
-    AV1 encoded image tracks: primary and AV1 encoded thumbnail images.
-</p>
-
-<p>A JPEG encoded thumbnail shall conform to section H of the HEIF
-  specification and use the "jpgC" JpegConfigurationBox as its sample descriptor.
-</p>
-<p>For an alpha track, the AuxiliaryTypeInfoBox shall be used as SampleDescriptionBox
-  entry in the SampleTableBox for an alpha track. The aux_track_type
-  shall be assigned the string urn:aom:avif:alpha. This is the only type of auxiliary track
-  defined by this specification.
-</p>
-
-<h4 id="data-reference-box">DataReferenceBox</h4>
-
-<p>Only one type of DataReferenceBox table entry shall be used to
-  define to the location of an AVIF media data element: the DataEntryUrlBox. Furthermore,
-  the entry_flag must be set to 0x001 to signal that the data element
-  resides in the same file as the containing DataReferenceBox.
-</p>
 
 </body>

--- a/index.bs
+++ b/index.bs
@@ -18,17 +18,18 @@ Custom Warning Text: This specification is still at draft stage and should not b
 
 <div boilerplate='copyright'>
 <p>Copyright 2018, The Alliance for Open Media</p>
+
 <p>Licensing information is available at http://aomedia.org/license/</p>
-<p>
-  The MATERIALS ARE PROVIDED “AS IS.” The Alliance for Open Media, its members, and its contributors
-  expressly disclaim any warranties (express, implied, or otherwise), including implied warranties of
-  merchantability, non-infringement, fitness for a particular purpose, or title, related to the materials.
-  The entire risk as to implementing or otherwise using the materials is assumed by the implementer and user.
-  IN NO EVENT WILL THE ALLIANCE FOR OPEN MEDIA, ITS MEMBERS, OR CONTRIBUTORS BE LIABLE TO ANY OTHER PARTY
-  FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER
-  FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS DELIVERABLE OR ITS GOVERNING AGREEMENT,
-  WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT
-  THE OTHER MEMBER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGEd.
+
+<p>The MATERIALS ARE PROVIDED “AS IS.” The Alliance for Open Media, its members, and its contributors
+expressly disclaim any warranties (express, implied, or otherwise), including implied warranties of
+merchantability, non-infringement, fitness for a particular purpose, or title, related to the materials.
+The entire risk as to implementing or otherwise using the materials is assumed by the implementer and user.
+IN NO EVENT WILL THE ALLIANCE FOR OPEN MEDIA, ITS MEMBERS, OR CONTRIBUTORS BE LIABLE TO ANY OTHER PARTY
+FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER
+FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS DELIVERABLE OR ITS GOVERNING AGREEMENT,
+WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT
+THE OTHER MEMBER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 </p>
 </div>
 
@@ -37,65 +38,59 @@ Custom Warning Text: This specification is still at draft stage and should not b
 
 <h2 id="overview">Overview</h2>
 
-<p>
-  AVIF is a file format wrapping compressed images based on the
-  <a href="http://aomedia.org">Alliance for Open Media</a> AV1 intra-frame encoding toolkit.
-  AVIF supports High Dynamic Range (HDR) and wide color gamut (WCG) images as well as standard
-  dynamic range (SDR). Only the intra-frame encoding toolkit is used in AVIF version 1.0. Using
-  the intra-frame encoding mechanism from an existing video codec standard has a precedent in WebP:
-  VP8, and HEIF: HEVC. This document describes at a high level a proposal on the structure of AVIF version 1.0.
+<p>AVIF is a file format wrapping compressed images based on the
+<a href="http://aomedia.org">Alliance for Open Media</a> AV1 intra-frame encoding toolkit.
+AVIF supports High Dynamic Range (HDR) and wide color gamut (WCG) images as well as standard
+dynamic range (SDR). Only the intra-frame encoding toolkit is used in AVIF version 1.0. Using
+the intra-frame encoding mechanism from an existing video codec standard has a precedent in WebP:
+VP8, and HEIF: HEVC. This document describes at a high level a proposal on the structure of AVIF version 1.0.
 </p>
 
-<p>
-  The initial version of AVIF seeks to be simple, with just enough structure to allow the distribution
-  of images based on the AV1 intra-frame coding toolset. At its core, AVIF 1.0 will allow for one or more
-  images plus all supporting data needed to correctly reconstruct and display the images to be conveyed
-  in a file. The ability to embed a thumbnail image will also be provided. An image sequence with suggested
-  playback timing may be defined.
+<p>The initial version of AVIF seeks to be simple, with just enough structure to allow the distribution
+of images based on the AV1 intra-frame coding toolset. At its core, AVIF 1.0 will allow for one or more
+images plus all supporting data needed to correctly reconstruct and display the images to be conveyed
+in a file. The ability to embed a thumbnail image will also be provided. An image sequence with suggested
+playback timing may be defined.
 </p>
 
 <h3 id="target-features">Target Features</h3>
-  <ul>
-    <li>AV1 intra-frame codec toolkit</li>
-    <li>Multiple image storage: untimed unordered collection</li>
-    <li>Animation: timed sequence of images</li>
-    <li>Thumbnail image</li>
-    <li>Alpha channel</li>
-    <li>Extensible image metadata</li>
-  </ul>
+<ul>
+  <li>AV1 intra-frame codec toolkit</li>
+  <li>Multiple image storage: untimed unordered collection</li>
+  <li>Animation: timed sequence of images</li>
+  <li>Thumbnail image</li>
+  <li>Alpha channel</li>
+  <li>Extensible image metadata</li>
+</ul>
 
 <h2 id="terms-and-definitions">Terms and Definitions</h2>
 
 <h3 id="def-alpha-image"><dfn>Alpha Image</dfn></h3>
-<p>
-  A specific type of [=Auxiliary Image=] that may be used to convey information representing
-  the opacity of associated [=Master Images=].
+<p>A specific type of [=Auxiliary Image=] that may be used to convey information representing
+the opacity of associated [=Master Images=].
 </p>
 
 <h3 id="def-auxiliary-image"><dfn>Auxiliary Image</dfn></h3>
-<p>
-  An image that is not be intended to be displayed but provides supplemental information for
-  associated [=Master Images=]. AVIF allows only one type of Auxiliary Image: an [=Alpha Image=].
+<p>An image that is not be intended to be displayed but provides supplemental information for
+associated [=Master Images=]. AVIF allows only one type of Auxiliary Image: an [=Alpha Image=].
 </p>
 
 <h3 id="def-cover-image"><dfn>Cover Image</dfn></h3>
-<p>
-  A [=Master Image=] that may be used to represent the file contents. An example of this is
-  a single image used to represent an animation before the animation sequence is activated.
+<p>A [=Master Image=] that may be used to represent the file contents. An example of this is
+a single image used to represent an animation before the animation sequence is activated.
 </p>
 
 <h3 id="def-image-collection"><dfn>Image Collection</dfn></h3>
-<p>
-  One or more [=Master Images=] stored as items in a single file with no defined order or
-  timing information. Within a collection, groups of image samples may share properties and metadata.
+<p>One or more [=Master Images=] stored as items in a single file with no defined order or
+timing information. Within a collection, groups of image samples may share properties and metadata.
 </p>
 
 <h3 id="def-image-properties"><dfn>Image Properties</dfn></h3>
-<p>
-  This is a class of non-media data. The property items may be descriptive image attribute
-  or decoder configuration data. The properties are primarily for consumption by the decoding
-  agent. This information may include:
+<p>This is a class of non-media data. The property items may be descriptive image attribute
+or decoder configuration data. The properties are primarily for consumption by the decoding
+agent. This information may include:
 </p>
+
 <ul>
   <li>decoder specific configuration and initialization values</li>
   <li>image width and height</li>
@@ -104,485 +99,629 @@ Custom Warning Text: This specification is still at draft stage and should not b
 </ul>
 
 <h3 id="def-image-sequence"><dfn>Image Sequence</dfn></h3>
-<p>A sequence of [=Master Images=] stored as a track for which information is provided that defines a sequential ordering and temporal information indicating suggested playback timing. An agent decoding and presenting an AVIF file may chose to render an Image Sequence as an animation.
-  </p>
 
-  <h3 id="def-master-image"><dfn>Master Image</dfn></h3>
-  <p>An image that is not a thumbnail or auxiliary image. For the purpose of this specification, such an image is encoded using AV1 intra-frame tools. This type of image is the primary displayable payload of an AVIF file. A Master Image may be used as a member of both an Image Collection and an Image Sequence.
-  </p>
+<p>A sequence of [=Master Images=] stored as a track for which information is provided that defines a
+sequential ordering and temporal information indicating suggested playback timing. An agent decoding
+and presenting an AVIF file may chose to render an Image Sequence as an animation.
+</p>
 
-  <h3 id="def-metadata"><dfn>Metadata</dfn></h3>
-  <p>Metadata conveys image attributes that are not used to decode or reconstruct an image. This data is considered to be non-essential and non-normative. Examples of this include EXIF, XMP, and MPEG-7. An AVIF reader will not be required to extract metadata from a Informational Metadata boxes. Essential information shall be carried in the image media directly or be conveyed as Image Properties.
-  </p>
+<h3 id="def-master-image"><dfn>Master Image</dfn></h3>
 
-  <h3 id="def-thumbnail-image"><dfn>Thumbnail Image</dfn></h3>
-  <p>This is a non-master image that may be used to represent one or more [=Master Images=] found in an AVIF file. It is typically of a smaller scale than the Master Images. Its compression format may be different than the one used by the Master Images.
-  </p>
+<p>An image that is not a thumbnail or auxiliary image. For the purpose of this specification,
+such an image is encoded using AV1 intra-frame tools. This type of image is the primary displayable
+payload of an AVIF file. A Master Image may be used as a member of both an Image Collection and an
+Image Sequence.
+</p>
 
-  <h2 id="object-model-and-structure">Object Model and Structure</h2>
-    <p>An AVIF file should be a simplified and conformant version of an [[!HEIF]] file. This is to allow for the deployment of general libraries that may be used to create and parse HEIF-based image files wrapping different coding methods for the actual image content. This should be similar to ISO-BMFF usage in the video domain.
-    </p>
-    <p>The AVIF file format will be built on the box-structured media interchange format introduced by the ISO Base Media File Format ([[!ISOBMFF]]). The format specified by AVIF defines the use of a subset of box structures introduced in ISOBMFF. Where the necessary structures do not exist in ISOBMFF, structures defined as part of the High Efficiency Image File Format ([[!HEIF]]: ISO/IEC 23008-12) that are codec neutral and can be applied in a generic manner are used. An AVIF version 1.0 file shall be compliant to the requirements of Clause 4 of the [[!ISOBMFF]] specification, and where applicable, the recommendations in Annex I: Guidelines On Defining New Image Formats and Brands in the MPEG HEIF specification shall be followed for AVIF 1.0.
-    </p>
+<h3 id="def-metadata"><dfn>Metadata</dfn></h3>
 
-    <h3 id="image-storage">Image Storage</h3>
-    <p>All of the constituent elements, including image samples, shall be contained in a single file. All media data locations, regardless of construction method, shall resolve to an offset within an AVIF file.
-    </p>
+<p>Metadata conveys image attributes that are not used to decode or reconstruct an image. This data is
+considered to be non-essential and non-normative. Examples of this include EXIF, XMP, and MPEG-7.
+An AVIF reader will not be required to extract metadata from a Informational Metadata boxes. Essential
+information shall be carried in the image media directly or be conveyed as Image Properties.
+</p>
 
-    <h3 id="image-collection-elements">Image Collection Elements</h3>
-    <p>An Image Collection is the most basic format of an AVIF file. This form should be used for the case of a single image, or when a group of images that have no logical or temporal sequencing.
-    </p>
-    <p>Image Collections are structured as items defined in a single file-level MetaBox. Each master, thumbnail or auxiliary image that are a component of the Image Collection shall have an item definition in this MetaBox. Items have no timing information. Any association between a Master Image and an Auxiliary or Thumbnail image must be defined explicitly.
-    </p>
-    <p>An AVIF file containing an Image Collection shall list the "mif1" brand as one of the entries in the compatible_brands array and conform to section 10.1 of [[!HEIF]]. All boxes used to structure a collection are located at the file level within a MetaBox: there are no track level boxes. The image data for a collection may be stored within an ItemDataBox or a MediaDataBox.
-    </p>
-    <p>The images stored in the file are listed in an ItemLocationBox. A unique ItemLocationBox entry shall be used to reference the media data for each image in the collection: Master, Thumbnail and Alpha images. Each image shall have an entry in the ItemLocationBox.
-    </p>
-    <p>The type of the item element is identified in an entry in the ItemInfoBox. Every ItemLocationBox entry shall have a matching entry in the ItemInfoBox cross referenced by the item_ID.
-    </p>
-    <p>The images making up an Image Collection do not need to have the same Image Properties. A specific property may be assigned to one or more of the images within the Image Collection using an ItemPropertyBox entry.
-    </p>
+<h3 id="def-thumbnail-image"><dfn>Thumbnail Image</dfn></h3>
 
-    <h3 id="image-sequence-elements">Image Sequence Elements</h3>
-    <p>Image Sequences are structured as tracks. An individual track shall contain one type of image: master, auxiliary or thumbnail. Associations between a thumbnail or auxiliary image, and a master image, is determined by finding components of each track that are time-parallel as defined by procedures detailed in [[!ISOBMFF]].
-    </p>
-    <p>An AVIF file containing an Image Sequence shall list the "msf1" brand as one of the entries in the compatible_brands array.
-    </p>
-    <p>The timing information provided for a Master Image track is advisory. However, the timing relationship between the master track and any associated non-master track shall be treated strictly when used to determine which images are time-parallel.
-    </p>
-    <p>All Master Images that are part of a sequence shall share the same Image Properties. Any Image Properties assigned to the sequence shall be linked to the track and shall not be linked to an individual image sample. Image Properties are linked to tracks by setting the item_ID field of an ItemPropertyAssociation to a track_id.
-    </p>
-    <p>The determination as to which master track images a non-master image is bound to is made after the decoding sample time is reconstructed for all tracks of the Image Sequence using the TimeToSampleBox (stts) information associated with each track. A non-master image is linked to each master image that has a decode time equal the decode time for that image or falls within the period before the decode time of the next non-master image in the track sequence.
-    </p>
+<p>This is a non-master image that may be used to represent one or more [=Master Images=] found in an
+AVIF file. It is typically of a smaller scale than the Master Images. Its compression format may be
+different than the one used by theMaster Images.
+</p>
 
-    <figure>
-    	<img alt="Determining time-parallel images between track using decode time." src="images/track_matching.svg">
-    	<figcaption>Determining time-parallel images between track using decode time</figcaption>
-    </figure>
+<h2 id="object-model-and-structure">Object Model and Structure</h2>
 
-    <h3 id="thumbnails">Thumbnails</h3>
-    <p>For Image Collections, a Thumbnail Image and one or more Master Images shall be linked using an ItemReferenceBox entry with a referenceType of "thmb" in the file-level MetaBox. A single thumbnail may be linked to multiple non-sequential Master Images in the collection.
-    </p>
-    <p>For Image Sequences, a Thumbnail Image track may be associated with the Master Image track. The thumbnail track may contain one or more images. The number of Thumbnail Images shall not exceed the number of Master Images. Presentation timing for the thumbnail track is derived from the track-level TimeToSampleBox and may be treated as advisory for playback. A thumbnail track shall be associated with the primary track using a TrackReferenceBox with a referenceType of "thmb".
-    </p>
+<p>An AVIF file should be a simplified and conformant version of an [[!HEIF]] file.
+This is to allow for the deployment of general libraries that may be used to create and parse
+HEIF-based image files wrapping different coding methods for the actual image content.
+This should be similar to ISO-BMFF usage in the video domain.
+</p>
+<p>
+The AVIF file format will be built on the box-structured media interchange format introduced
+by the ISO Base Media File Format ([[!ISOBMFF]]). The format specified by AVIF defines the use
+of a subset of box structures introduced in ISOBMFF. Where the necessary structures do not
+exist in ISOBMFF, structures defined as part of the High Efficiency Image File Format
+([[!HEIF]]: ISO/IEC 23008-12) that are codec neutral and can be applied in a generic manner
+are used. An AVIF version 1.0 file shall be compliant to the requirements of Clause 4 of the
+[[!ISOBMFF]] specification, and where applicable, the recommendations in Annex I: Guidelines
+On Defining New Image Formats and Brands in the MPEG HEIF specification shall be followed
+for AVIF 1.0.
+</p>
 
-    <h3 id="cover-image">Cover Image</h3>
-    <p>A Cover Image differs from a Thumbnail Image in that it is also a Master Image.
-    For Image Collections, a PrimaryItemBox found in the file-level MetaBox may be used to
-    indicate the image item that is to be considered the Cover Image. This image item
-    shall be a master image. If not explicitly indicated in the above manner, the
-    Cover Image shall be assumed to be the first master image entry in the ItemLocationBox.
-    <p>For an Image Sequence, a PrimaryItemBox in a MetaBox found in the TrackBox
-    of the master image track may be used to indicate the Cover Image. The MetaBox
-    containing this PrimaryItemBox shall have a HandlerBox with a hander_type set to "pict"
-    and an ItemLocationBox that has an entry with the same item_ID that is contained
-    in the PrimaryItemBox. The item identified by the item_ID shall a Master Image.
-    If not explicitly indicated in the above manner, the Cover Image shall be assumed
-    to be first entry in the master track.
-    </p>
+<h3 id="image-storage">Image Storage</h3>
 
-    <h3 id="alpha-channel">Alpha Channel</h3>
-    <p>An Alpha Image is a specific type of auxiliary image that is used to carry per pixel opacity information for one or more Master Images. This is the only type of Auxiliary Image supported by AVIF.
-    </p>
-    <p>A URN will be defined to identify AVIF alpha auxiliary images or tracks. For the purposes of this draft the placeholder urn:aom:avif:alpha will be used.
-    </p>
-    <p>A brand that represents the encoding format of the alpha image shall be placed in the compatible_brands array of the FileTypeBox.
-    </p>
-    <p>The alpha image shall have the same dimensional attributes as the largest channel plane in the Master Image: width, height, and pixel aspect ratio. Furthermore, the pixels of the Alpha Image shall overlay the pixels of the largest component plane of any linked Master Image exactly. For example, for YUV 4:2:x, this would be the Y component plane. The decoded value of an alpha pixel shall be a normalized unsigned integer of at least 8 bits representing a value between 0.0 and 1.0 or a floating point value between 0.0 and 1.0.
-    </p>
-    <p>For an Image Collection, Alpha Images and Master Images shall be linked using an ItemReferenceBox entry with a reference type of "auxl". A single Alpha Image may be linked to one or more Master Images. The total number of Alpha Images shall not exceed the number of Master Images. When an Alpha Image applies to a subset of the Master Image items this shall constrain all Master Images in that subset to have the same dimensional attributes.
-    </p>
-    <p>When the AVIF file is structured as an Image Sequence, Alpha images may be associated with an Image Sequence using an associated auxiliary track. This track shall have a TrackReferenceBox with a referenceType of "auxl" with an auxiliary type of urn:aom:avif:alpha. For AVIF, only one alpha track may be included in the file. Linking of samples in the Alpha Image track and Master Image track is defined by derived parallel time alignment using each stream's TimeToSampleBox. The timing relationship between alpha track and primary track is strict and shall not be treated as advisory. At a minimum, the alpha track shall contain a single image.
-    </p>
+<p>All of the constituent elements, including image samples, shall be contained in a single
+file. All media data locations, regardless of construction method, shall resolve to an offset
+within an AVIF file.
+</p>
 
-    <h3 id="metadata">Metadata</h3>
-    <p>Metadata is associated through a "cdsc" (content describes) item referenceType element in an ItemReferenceBox for an Image Collection, or a TrackReferenceBox for an Image Sequence. A conforming AVIF reader may ignore all metadata.
-    </p>
+<h3 id="image-collection-elements">Image Collection Elements</h3>
+
+<p>An Image Collection is the most basic format of an AVIF file. This form should be used for
+the case of a single image, or when a group of images that have no logical or temporal sequencing.
+</p>
+<p>Image Collections are structured as items defined in a single file-level MetaBox. Each master,
+thumbnail or auxiliary image that are a component of the Image Collection shall have an item definition
+in this MetaBox. Items have no timing information. Any association between a Master Image and
+an Auxiliary or Thumbnail image must be defined explicitly.
+</p>
+<p>An AVIF file containing an Image Collection shall list the "mif1" brand as one of the entries in
+the compatible_brands array and conform to section 10.1 of [[!HEIF]]. All boxes used to structure
+a collection are located at the file level within a MetaBox: there are no track level boxes.
+The image data for a collection may be stored within an ItemDataBox or a MediaDataBox.
+</p>
+<p>The images stored in the file are listed in an ItemLocationBox. A unique ItemLocationBox entry
+shall be used to reference the media data for each image in the collection: Master, Thumbnail
+and Alpha images. Each image shall have an entry in the ItemLocationBox.
+</p>
+<p>The type of the item element is identified in an entry in the ItemInfoBox. Every ItemLocationBox
+entry shall have a matching entry in the ItemInfoBox cross referenced by the item_ID.
+</p>
+<p>The images making up an Image Collection do not need to have the same Image Properties.
+A specific property may be assigned to one or more of the images within the Image Collection
+using an ItemPropertyBox entry.
+</p>
+
+<h3 id="image-sequence-elements">Image Sequence Elements</h3>
+
+<p>Image Sequences are structured as tracks. An individual track shall contain one type of image:
+master, auxiliary or thumbnail. Associations between a thumbnail or auxiliary image, and a master
+image, is determined by finding components of each track that are time-parallel as defined by procedures
+detailed in [[!ISOBMFF]].
+</p>
+<p>An AVIF file containing an Image Sequence shall list the "msf1" brand as one of the entries in the
+compatible_brands array.
+</p>
+<p>The timing information provided for a Master Image track is advisory. However, the timing
+relationship between the master track and any associated non-master track shall be treated strictly
+when used to determine which images are time-parallel.
+</p>
+<p>All Master Images that are part of a sequence shall share the same Image Properties. Any Image
+Properties assigned to the sequence shall be linked to the track and shall not be linked to an
+individual image sample. Image Properties are linked to tracks by setting the item_ID field of
+an ItemPropertyAssociation to a track_id.
+</p>
+<p>The determination as to which master track images a non-master image is bound to is made after
+the decoding sample time is reconstructed for all tracks of the Image Sequence using the TimeToSampleBox
+(stts) information associated with each track. A non-master image is linked to each master image that
+has a decode time equal the decode time for that image or falls within the period before the decode time
+of the next non-master image in the track sequence.
+</p>
+
+<figure>
+  <img alt="Determining time-parallel images between track using decode time." src="images/track_matching.svg">
+  <figcaption>Determining time-parallel images between track using decode time</figcaption>
+</figure>
+
+<h3 id="thumbnails">Thumbnails</h3>
+
+<p>For Image Collections, a Thumbnail Image and one or more Master Images shall be linked using an
+ItemReferenceBox entry with a referenceType of "thmb" in the file-level MetaBox. A single thumbnail
+may be linked to multiple non-sequential Master Images in the collection.
+</p>
+<p>For Image Sequences, a Thumbnail Image track may be associated with the Master Image track.
+The thumbnail track may contain one or more images. The number of Thumbnail Images shall not exceed
+the number of Master Images. Presentation timing for the thumbnail track is derived from the track-level
+TimeToSampleBox and may be treated as advisory for playback. A thumbnail track shall be associated with
+the primary track using a TrackReferenceBox with a referenceType of "thmb".
+</p>
+
+<h3 id="cover-image">Cover Image</h3>
+
+<p>A Cover Image differs from a Thumbnail Image in that it is also a Master Image.
+For Image Collections, a PrimaryItemBox found in the file-level MetaBox may be used to
+indicate the image item that is to be considered the Cover Image. This image item
+shall be a master image. If not explicitly indicated in the above manner, the
+Cover Image shall be assumed to be the first master image entry in the ItemLocationBox.
+</p>
+<p>For an Image Sequence, a PrimaryItemBox in a MetaBox found in the TrackBox
+of the master image track may be used to indicate the Cover Image. The MetaBox
+containing this PrimaryItemBox shall have a HandlerBox with a hander_type set to "pict"
+and an ItemLocationBox that has an entry with the same item_ID that is contained
+in the PrimaryItemBox. The item identified by the item_ID shall a Master Image.
+If not explicitly indicated in the above manner, the Cover Image shall be assumed
+to be first entry in the master track.
+</p>
+
+<h3 id="alpha-channel">Alpha Channel</h3>
+<p>An Alpha Image is a specific type of auxiliary image that is used to carry per
+pixel opacity information for one or more Master Images. This is the only type of
+Auxiliary Image supported by AVIF.
+</p>
+<p>A URN will be defined to identify AVIF alpha auxiliary images or tracks. For the
+purposes of this draft the placeholder urn:aom:avif:alpha will be used.
+</p>
+<p>A brand that represents the encoding format of the alpha image shall be placed in
+the compatible_brands array of the FileTypeBox.
+</p>
+<p>The alpha image shall have the same dimensional attributes as the largest channel
+plane in the Master Image: width, height, and pixel aspect ratio. Furthermore, the pixels
+of the Alpha Image shall overlay the pixels of the largest component plane of any linked
+Master Image exactly. For example, for YUV 4:2:x, this would be the Y component plane.
+The decoded value of an alpha pixel shall be a normalized unsigned integer of at least
+8 bits representing a value between 0.0 and 1.0 or a floating point value between 0.0 and 1.0.
+</p>
+<p>For an Image Collection, Alpha Images and Master Images shall be linked using an
+ItemReferenceBox entry with a reference type of "auxl". A single Alpha Image may be linked
+to one or more Master Images. The total number of Alpha Images shall not exceed the number
+of Master Images. When an Alpha Image applies to a subset of the Master Image items this
+shall constrain all Master Images in that subset to have the same dimensional attributes.
+</p>
+<p>When the AVIF file is structured as an Image Sequence, Alpha images may be associated
+with an Image Sequence using an associated auxiliary track. This track shall have a TrackReferenceBox
+with a referenceType of "auxl" with an auxiliary type of urn:aom:avif:alpha. For AVIF, only
+one alpha track may be included in the file. Linking of samples in the Alpha Image track
+and Master Image track is defined by derived parallel time alignment using each stream's
+TimeToSampleBox. The timing relationship between alpha track and primary track is strict
+and shall not be treated as advisory. At a minimum, the alpha track shall contain a single image.
+</p>
+
+<h3 id="metadata">Metadata</h3>
+
+<p>Metadata is associated through a "cdsc" (content describes) item referenceType element
+in an ItemReferenceBox for an Image Collection, or a TrackReferenceBox for an Image Sequence.
+A conforming AVIF reader may ignore all metadata.
+</p>
 
 <h2 id="file-format">File Format</h2>
-
 <h3 id="common-elements">Common Elements</h3>
-    <h4 id="file-type-box">FileTypeBox</h4>
-    <p>Each AVIF file will begin with a FileTypeBox. This shall be the first box in the file and may only be preceded by non-ISOBMFF data when necessary. The box should identify this file as conforming to HEIF with specific branding registered for AVIF.
-    </p>
-    <p>If the major_brand field is set to "avif" then the minor_version shall be set to 0.
-    </p>
-    <p>If the major_brand field is not set to "avif", then the brand "avif" shall appear in the compatible_brands array.
-    </p>
-    <p>The compatible_brands array shall contain "mif1" if the file contains an Image Collection.
-    </p>
-    <p>The compatible_brands array shall contain "msf1" if the file contains an Image Sequence.
-    </p>
-    <p>The compatible_brands array shall contain an appropriate brand for the encoding used for thumbnails images if it is not AV1.
-    </p>
-    <p>The compatible_brands array shall contain an appropriate brand for the encoding used for alpha images if it is not AV1.
-    </p>
+<h4 id="file-type-box">FileTypeBox</h4>
+
+<p>Each AVIF file will begin with a FileTypeBox. This shall be the first box in the file
+and may only be preceded by non-ISOBMFF data when necessary. The box should identify this
+file as conforming to HEIF with specific branding registered for AVIF.
+</p>
+<p>If the major_brand field is set to "avif" then the minor_version shall be set to 0.
+</p>
+<p>If the major_brand field is not set to "avif", then the brand "avif" shall appear in
+the compatible_brands array.
+</p>
+<p>The compatible_brands array shall contain "mif1" if the file contains an Image Collection.
+</p>
+<p>The compatible_brands array shall contain "msf1" if the file contains an Image Sequence.
+</p>
+<p>The compatible_brands array shall contain an appropriate brand for the encoding used
+for thumbnails images if it is not AV1.
+</p>
+<p>The compatible_brands array shall contain an appropriate brand for the encoding used
+for alpha images if it is not AV1.
+</p>
 
 <h3 id="collection-elements">Collection Elements</h3>
-    <p>An AVIF file reader must be able to recognize the following boxes. Any box field or feature not explicitly limited by this specification should be handled as defined in ISO 14496&#8209;12 and ISO 23008-12.
-    </p>
-    <table class="complex data" style="border: 2px solid;">
-    <colgroup>
-      <col span="3">
-      <col style="border-right: 2px solid; border-left: 2px solid">
-    </colgroup>
-    <thead>
-      <tr>
-        <td colspan="3" rowspan="1">box hierarchy</td>
-        <td>version</td>
-        <td>box description</td>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>ftyp</td>
-        <td></td>
-        <td></td>
-        <td>-</td>
-        <td>file type</td>
-      </tr>
-      <tr>
-        <td>meta</td>
-        <td></td>
-        <td></td>
-        <td>0</td>
-        <td>metadata container box</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td>hdlr</td>
-        <td></td>
-        <td>0</td>
-        <td>handler type definition</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td>pitm</td>
-        <td></td>
-        <td>0,1</td>
-        <td>primary item reference</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td>iloc</td>
-        <td></td>
-        <td>0,1,2</td>
-        <td>item location table</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td>iinf</td>
-        <td></td>
-        <td>0,1</td>
-        <td>item information table</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td></td>
-        <td>infe</td>
-        <td>2,3</td>
-        <td>item information table entry</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td>iprp</td>
-        <td></td>
-        <td>-</td>
-        <td>item properties container box</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td></td>
-        <td>ipco</td>
-        <td>0</td>
-        <td>item property definitions</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td></td>
-        <td>ipma</td>
-        <td>0,1</td>
-        <td>item property associations</td>
-      </tr>
-    </tbody>
-  </table>
+
+<p>An AVIF file reader must be able to recognize the following boxes. Any box field or
+feature not explicitly limited by this specification should be handled as defined in
+ISO 14496&#8209;12 and ISO 23008-12.
+</p>
+
+<table class="complex data" style="border: 2px solid;">
+  <colgroup>
+    <col span="3">
+    <col style="border-right: 2px solid; border-left: 2px solid">
+  </colgroup>
+  <thead>
+    <tr>
+      <td colspan="3" rowspan="1">box hierarchy</td>
+      <td>version</td>
+      <td>box description</td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>ftyp</td>
+      <td></td>
+      <td></td>
+      <td>-</td>
+      <td>file type</td>
+    </tr>
+    <tr>
+      <td>meta</td>
+      <td></td>
+      <td></td>
+      <td>0</td>
+      <td>metadata container box</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>hdlr</td>
+      <td></td>
+      <td>0</td>
+      <td>handler type definition</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>pitm</td>
+      <td></td>
+      <td>0,1</td>
+      <td>primary item reference</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>iloc</td>
+      <td></td>
+      <td>0,1,2</td>
+      <td>item location table</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>iinf</td>
+      <td></td>
+      <td>0,1</td>
+      <td>item information table</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td></td>
+      <td>infe</td>
+      <td>2,3</td>
+      <td>item information table entry</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>iprp</td>
+      <td></td>
+      <td>-</td>
+      <td>item properties container box</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td></td>
+      <td>ipco</td>
+      <td>0</td>
+      <td>item property definitions</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td></td>
+      <td>ipma</td>
+      <td>0,1</td>
+      <td>item property associations</td>
+    </tr>
+  </tbody>
+</table>
 
 <h4 id="meta-box">MetaBox</h4>
-  <p>A file-level MetaBox shall follow immediately after the FileTypeBox if the file contains an Image Collection.
-  </p>
+<p>A file-level MetaBox shall follow immediately after the FileTypeBox if the file contains an Image Collection.
+ </p>
 
 <h4 id="handler-box">HandlerBox</h4>
-  <p>The handler type for the MetaBox shall be "pict".
-  </p>
+
+<p>The handler type for the MetaBox shall be "pict".
+</p>
 
 <h4 id="primary-item-box">PrimaryItemBox</h4>
-  <p>One PrimaryItemBox may be used in this MetaBox to provide a reference to a Cover Image.
-  The image referenced by the PrimaryItemBox shall be a Master Image.
-  The PrimaryItemBox shall come before the ItemLocationBox.
-  </p>
+
+<p>One PrimaryItemBox may be used in this MetaBox to provide a reference to a Cover Image.
+The image referenced by the PrimaryItemBox shall be a Master Image.
+The PrimaryItemBox shall come before the ItemLocationBox.
+</p>
 
 <h4 id="item-location-box">ItemLocationBox</h4>
-  <p>The data_reference_index for any AVIF conformant element in the ItemLocationBox table entry shall be set to zero.
-  </p>
-  <p>The construction_method value of 2 shall not be used.
-  </p>
+
+<p>The data_reference_index for any AVIF conformant element in the ItemLocationBox
+table entry shall be set to zero.
+</p>
+<p>The construction_method value of 2 shall not be used.
+</p>
 
 <h4 id="item-properties-box">ItemPropertiesBox</h4>
-  <p>Item Properties are associated with an item using an ItemPropertiesBox. The type of each property is uniquely identified with a fourCC. Two categories of image properties may be found in an AVIF file.
-  </p>
-  <p>The first catagory are decoder specific configuration and initialization properties. The AVIF codec configuration property will be identified with a property type of "av1C". For non-master image types recommendations may also define codec configuration property formats and usage rules.
-  </p>
-  <p>The second are image descriptive properties conveying the attributes of the encoded image and, by implication, the reconstructed image post decode. The descriptive image properties that may be used in AVIF compliant files are:
-  </p>
-  <ul>
-    <li>Image Spatial Extents (ispe)</li>
-    <li>Pixel Aspect Ratio (pasp)</li>
-    <li>Colour Information (colr)</li>
-    <li>Pixel Information (pixi)</li>
-    <li>Image Rotation (irot)</li>
-    <li>Clean Aperture (clap)</li>
-    <li>Relative Location (rloc)</li>
-    <li>Image Mirroring (imir)</li>
-    <li>Image properties for auxiliary images (auxC)</li>
-  </ul>
+
+<p>Item Properties are associated with an item using an ItemPropertiesBox.
+The type of each property is uniquely identified with a fourCC. Two categories
+of image properties may be found in an AVIF file.
+</p>
+<p>The first catagory are decoder specific configuration and initialization properties.
+The AVIF codec configuration property will be identified with a property type of "av1C".
+For non-master image types recommendations may also define codec configuration property
+formats and usage rules.
+</p>
+<p>The second are image descriptive properties conveying the attributes of the encoded
+image and, by implication, the reconstructed image post decode. The descriptive image
+properties that may be used in AVIF compliant files are:
+</p>
+
+<ul>
+  <li>Image Spatial Extents (ispe)</li>
+  <li>Pixel Aspect Ratio (pasp)</li>
+  <li>Colour Information (colr)</li>
+  <li>Pixel Information (pixi)</li>
+  <li>Image Rotation (irot)</li>
+  <li>Clean Aperture (clap)</li>
+  <li>Relative Location (rloc)</li>
+  <li>Image Mirroring (imir)</li>
+  <li>Image properties for auxiliary images (auxC)</li>
+</ul>
 
 <h4 id="item-info-box">ItemInfoBox</h4>
-  <p>All images samples that are members of the Image Collection shall have an entry in the ItemInfoBox item_infos table. This includes primary, thumbnail, and alpha images
-  </p>
-  <p>Image samples of the collection shall use version 2 or 3 of the ItemInfoEntry box.
-  </p>
-  <p>Each ItemInfoEntry referencing a master image shall have an item_type of "av1i".
-  </p>
-  <p>Each ItemInfoEntry referencing an alpha plane image shall have an item_type field of"uri" and an item_uri_type set to "urn:aom:avif:alpha".
-  </p>
-  <p>Each ItemInfoEntry referencing a thumbnail image shall have an item_type field set to either"av1i" or"jpeg".
-  </p>
-  <p>The item_name is optional. A single byte null string shall be used to indicate an empty item_name.
-  </p>
+
+<p>All images samples that are members of the Image Collection shall have an entry
+in the ItemInfoBox item_infos table. This includes primary, thumbnail, and alpha images
+</p>
+<p>Image samples of the collection shall use version 2 or 3 of the ItemInfoEntry box.
+</p>
+<p>Each ItemInfoEntry referencing a master image shall have an item_type of "av1i".
+</p>
+<p>Each ItemInfoEntry referencing an alpha plane image shall have an item_type field
+of"uri" and an item_uri_type set to "urn:aom:avif:alpha".
+</p>
+<p>Each ItemInfoEntry referencing a thumbnail image shall have an item_type field set
+to either"av1i" or"jpeg".
+</p>
+<p>The item_name is optional. A single byte null string shall be used to indicate
+an empty item_name.
+</p>
 
 <h4 id="item-reference-box">ItemReferenceBox</h4>
-  <p>An AVIF file reader shall support item references of the following types:
-  </p>
-  <ul>
-    <li>"auxl" auxiliary image; limited to an aux_type of urn:aom:avif:alpha</li>
-    <li>"thmb" thumbnail image; limited to"av1i" or"jpeg"</li>
-  </ul>
-  <p>An AVIF file reader may optionally support item references of the follow type:
-  </p>
-  <ul>
-    <li>"cdsc" content description</li>
-  </ul>
+
+<p>An AVIF file reader shall support item references of the following types:
+</p>
+
+<ul>
+  <li>"auxl" auxiliary image; limited to an aux_type of urn:aom:avif:alpha</li>
+  <li>"thmb" thumbnail image; limited to"av1i" or"jpeg"</li>
+</ul>
+
+<p>An AVIF file reader may optionally support item references of the follow type:
+</p>
+
+<ul>
+  <li>"cdsc" content description</li>
+</ul>
+
 <h4 id="item-data-box">ItemDataBox</h4>
-  <p>An ItemDataBox shall be used if any ItemLocationBox entry has an"idat" construction method.
-  </p>
 
-  <h3 id="sequence-elements">Sequence Elements</h3>
-  <p>An AVIF file reader must be able recognize the following boxes. Any box field or feature not explicitly limited by this specification should be handled as defined in ISO 14496&#8209;12 and ISO 23008-12.
-  </p>
+<p>An ItemDataBox shall be used if any ItemLocationBox entry has an"idat" construction method.
+</p>
 
-  <table class="complex data" style="border: 2px solid;">
+<h3 id="sequence-elements">Sequence Elements</h3>
+
+<p>An AVIF file reader must be able recognize the following boxes. Any box field or
+feature not explicitly limited by this specification should be handled as defined in
+ISO 14496&#8209;12 and ISO 23008-12.
+</p>
+
+<table class="complex data" style="border: 2px solid;">
   <colgroup>
     <col span="4">
     <col style="border-right: 2px solid; border-left: 2px solid">
   </colgroup>
-    <thead>
-      <tr>
-        <td colspan="4" rowspan="1">box hierarchy</td>
-        <td>version</td>
-        <td>box description</td>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>ftyp</td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td>-</td>
-        <td>file type</td>
-      </tr>
-      <tr>
-        <td>moov</td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td>-</td>
-        <td>movie container box</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td>trak</td>
-        <td></td>
-        <td></td>
-        <td>-</td>
-        <td>track container box</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td>tkhd</td>
-        <td></td>
-        <td></td>
-        <td>0,1</td>
-        <td>track header</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td>tref</td>
-        <td></td>
-        <td></td>
-        <td>-</td>
-        <td>track references</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td>mdia</td>
-        <td></td>
-        <td></td>
-        <td>-</td>
-        <td>media information container</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td>mdhd</td>
-        <td></td>
-        <td></td>
-        <td>0,1</td>
-        <td>media information header</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td>hdlr</td>
-        <td></td>
-        <td></td>
-        <td>0</td>
-        <td>media handler type</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td>minf</td>
-        <td></td>
-        <td></td>
-        <td>-</td>
-        <td>media information box</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td></td>
-        <td>vmhd</td>
-        <td></td>
-        <td></td>
-        <td>video media header</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td></td>
-        <td>dinf</td>
-        <td></td>
-        <td>-</td>
-        <td>data information container</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td>dref</td>
-        <td>0</td>
-        <td>data references for track sources</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td></td>
-        <td>stbl</td>
-        <td></td>
-        <td>-</td>
-        <td>sample table mapping container</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td>stts</td>
-        <td>0</td>
-        <td>sample to decode time table</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td>stsd</td>
-        <td></td>
-        <td>sample description(visual sample entry box subclass)</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td>stsz</td>
-        <td>0</td>
-        <td>sample size table</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td>stsc</td>
-        <td>0</td>
-        <td>sample to chunk table</td>
-      </tr>
-      <tr>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td>stco</td>
-        <td>0</td>
-        <td>chunk offset table</td>
-      </tr>
-      <tr>
-        <td>mdat</td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td>-</td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
+  <thead>
+    <tr>
+      <td colspan="4" rowspan="1">box hierarchy</td>
+      <td>version</td>
+      <td>box description</td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>ftyp</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>-</td>
+      <td>file type</td>
+    </tr>
+    <tr>
+      <td>moov</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>-</td>
+      <td>movie container box</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>trak</td>
+      <td></td>
+      <td></td>
+      <td>-</td>
+      <td>track container box</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>tkhd</td>
+      <td></td>
+      <td></td>
+      <td>0,1</td>
+      <td>track header</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>tref</td>
+      <td></td>
+      <td></td>
+      <td>-</td>
+      <td>track references</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>mdia</td>
+      <td></td>
+      <td></td>
+      <td>-</td>
+      <td>media information container</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>mdhd</td>
+      <td></td>
+      <td></td>
+      <td>0,1</td>
+      <td>media information header</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>hdlr</td>
+      <td></td>
+      <td></td>
+      <td>0</td>
+      <td>media handler type</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>minf</td>
+      <td></td>
+      <td></td>
+      <td>-</td>
+      <td>media information box</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td></td>
+      <td>vmhd</td>
+      <td></td>
+      <td></td>
+      <td>video media header</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td></td>
+      <td>dinf</td>
+      <td></td>
+      <td>-</td>
+      <td>data information container</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>dref</td>
+      <td>0</td>
+      <td>data references for track sources</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td></td>
+      <td>stbl</td>
+      <td></td>
+      <td>-</td>
+      <td>sample table mapping container</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>stts</td>
+      <td>0</td>
+      <td>sample to decode time table</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>stsd</td>
+      <td></td>
+      <td>sample description(visual sample entry box subclass)</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>stsz</td>
+      <td>0</td>
+      <td>sample size table</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>stsc</td>
+      <td>0</td>
+      <td>sample to chunk table</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>stco</td>
+      <td>0</td>
+      <td>chunk offset table</td>
+    </tr>
+    <tr>
+      <td>mdat</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>-</td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>
 
-  <h4 id="movie-box">MovieBox</h4>
-  <pThe Image Sequence tracks shall be contained in a MovieBox. The MovieBox should follow directly after either a file-level MetaBox, if one exists, or the FileTypeBox.
-  </p>
-  <h4 id="track-header-box">TrackHeaderBox</h4>
-  <p>For a track of sample type "av1i" the flag field shall be set to track_enabled and track_in_movie.
-  </p>
-  <p>For "thmb" the track_in_preview flag shall be set and track_in_movie cleared.
-  </p>
-  <p>For "auxv" (auxiliary used to convey alpha images) tracks the flag field shall be set to zero.
-  </p>
+<h4 id="movie-box">MovieBox</h4>
 
-  <h4 id="track-reference-box">TrackReferenceBox</h4>
-  <p>The reference_type values supported by an AVIF file shall be:
-  </p>
-  <ul>
-    <li>"thmb"thumbnail track</li>
-    <li>"auxl"; only when the auxiliary track type is alpha</li>
-  </ul>
+<p>The Image Sequence tracks shall be contained in a MovieBox. The
+ MovieBox should follow directly after either a file-level MetaBox, if one exists,
+ or the FileTypeBox.
+</p>
 
-  <h4 id="media-box">MediaBox</h4>
-  <p>Each MediaBox associated with AVIF elements "av1i" and "thmb" shall contain a HandlerBox with the handler_type shall be set to "pict".
-  </p>
-  <p>For alpha auxiliary tracks, the handler_type of the HandlerBox shall be "auxv".
-  </p>
+<h4 id="track-header-box">TrackHeaderBox</h4>
 
-  <h4 id="sample-table-box">SampleTableBox</h4>
-  <p>The "av1i" codec configuration (see ItemPropertyBox above) block shall be used as the AV1 specific version of the SampleDescriptionBox for all AV1 encoded image tracks: primary and AV1 encoded thumbnail images.
-  </p>
-  <p>A JPEG encoded thumbnail shall conform to section H of the HEIF specification and use the "jpgC" JpegConfigurationBox as its sample descriptor.
-  </p>
-  <p>For an alpha track, the AuxiliaryTypeInfoBox shall be used as SampleDescriptionBox entry in the SampleTableBox for an alpha track. The aux_track_type shall be assigned the string urn:aom:avif:alpha. This is the only type of auxiliary track defined by this specification.
-  </p>
+<p>For a track of sample type "av1i" the flag field shall be set to track_enabled and track_in_movie.
+</p>
+<p>For "thmb" the track_in_preview flag shall be set and track_in_movie cleared.
+</p>
+<p>For "auxv" (auxiliary used to convey alpha images) tracks the flag field shall be set to zero.
+</p>
 
-  <h4 id="data-reference-box">DataReferenceBox</h4>
-  <p>Only one type of DataReferenceBox table entry shall be used to define to the location of an AVIF media data element: the DataEntryUrlBox. Furthermore, the entry_flag must be set to 0x001 to signal that the data element resides in the same file as the containing DataReferenceBox.
-  </p>
+<h4 id="track-reference-box">TrackReferenceBox</h4>
+<p>The reference_type values supported by an AVIF file shall be:
+</p>
+
+<ul>
+  <li>"thmb"thumbnail track</li>
+  <li>"auxl"; only when the auxiliary track type is alpha</li>
+</ul>
+
+<h4 id="media-box">MediaBox</h4>
+
+<p>Each MediaBox associated with AVIF elements "av1i" and "thmb" shall
+  contain a HandlerBox
+  with the handler_type shall be set to "pict".
+</p>
+<p>For alpha auxiliary tracks, the handler_type of the HandlerBox shall be "auxv".
+</p>
+
+<h4 id="sample-table-box">SampleTableBox</h4>
+<p>The "av1i" codec configuration (see ItemPropertyBox above) block
+    shall be used as the AV1 specific version of the SampleDescriptionBox for all
+    AV1 encoded image tracks: primary and AV1 encoded thumbnail images.
+</p>
+
+<p>A JPEG encoded thumbnail shall conform to section H of the HEIF
+  specification and use the "jpgC" JpegConfigurationBox as its sample descriptor.
+</p>
+<p>For an alpha track, the AuxiliaryTypeInfoBox shall be used as SampleDescriptionBox
+  entry in the SampleTableBox for an alpha track. The aux_track_type
+  shall be assigned the string urn:aom:avif:alpha. This is the only type of auxiliary track
+  defined by this specification.
+</p>
+
+<h4 id="data-reference-box">DataReferenceBox</h4>
+
+<p>Only one type of DataReferenceBox table entry shall be used to
+  define to the location of an AVIF media data element: the DataEntryUrlBox. Furthermore,
+  the entry_flag must be set to 0x001 to signal that the data element
+  resides in the same file as the containing DataReferenceBox.
+</p>
 
 </body>


### PR DESCRIPTION
Specification is restructured to separate instructions on how to build an HEIF file that can wrap AV1 still images from the profile definition for a version 1.0 AVIF reader. I also removed text that was a restatement of items found in either HEIF or ISO-BMFF.