### PR TITLE
Add still_picture and reduced_still_picture_header references 

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -145,6 +145,14 @@ Each image shall conform to the requirements of an Intra Frame as defined by AV1
 [[!AV1-ISOBMFF]]. No inter-frame encoding shall be permitted between images.
 </p>
 
+<p>
+The image data shall have the "still_picture" field set to 1 in the sequence header OBU as specified in section 5.5.1 of the Bitstream & Decoding Process Specification [[!AV1]].
+</p>
+
+<p>
+The image data should have the "reduced_still_picture_header" field set to 1 in the sequence header OBU as specified in section 5.5.1 of the Bitstream & Decoding Process Specification [[!AV1]]. The field may be set to 0 to allow for easy extraction of frames from an AV1 file.
+</p>
+
 <h2 id="avif=image-collection">AVIF Image Collection</h2>
 
 <p>The image data of type "av1i" shall be used for an image collection item coded with AV1.


### PR DESCRIPTION
**Motivation**

The AV1 spec mentions to header fields that have meaning for still pictures. The `still_picture` field indicates that the stream consists of exactly one frame. This can be used by the decoder to avoid allocating resources for inter-frame decoding. Therefore, it's mentioned as must (shall).

The `reduced_still_picture_header` indicates that the header is not including fields that only have value for inter-frame encodings. Leaving them out saves size and therefore it is recommended (should). As described in https://aomediacodec.github.io/av1-spec/av1-spec.pdf on page 113, it might be set to 0 to allow for efficient extracting frames from an AV1 video.

**Changes**

Added two paragraphs in section 4 "Image Data"

As mentioned in https://github.com/AOMediaCodec/av1-avif/issues/7 the generated HTML file was way different from the current file. Therefore, I decided to leave out the `docs/index.html` regeneration.