### PR TITLE
Allow high profile for 'pict' tracks

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -153,5 +153,5 @@ In general, it is recommended to use properties instead of [=Metadata OBUs=] in 
 
 <p>If the brand <code>MiA1</code> is in the list of compatible_brands of a TrackTypeBox or FileTypeBox, the following constraints SHALL be respected:
 - The following "shared constraints" of [[!MIAF]] apply: self-containment, single-layer, grid-limit, single-track, and matched-duration.
-- For AV1 images stored as items or in 'pict' tracks, the profile SHALL be the Main Profile and the level SHALL be 6.0 level at Main tier or lower.
+- For AV1 images stored as items or in 'pict' tracks, the profile SHALL be the High Profile or lower and the level SHALL be 6.0 level or lower.
 - For AV1 images stored in video tracks, the profile level SHALL be Main Profile and the level SHALL be 5.1 level at Main tier or lower.</p>


### PR DESCRIPTION
Allowing high profile for pict tracks to enable use of 444 chroma sub-sampling. See issue #16 for motivation.

Also removing the "at Main tier" addition to the level constraint, as AV1 profiles and levels are independent of each other.

> The profile specifies the bit depth and subsampling formats supported, while the level defines resolution and performance characteristics. (https://aomediacodec.github.io/av1-spec/av1-spec.pdf, p647)

Not changing for the video tracks for now. The reason is that we'd want to be more conservative there as the decoder needs to playback in real time.