### PR TITLE
update abstract to clarify relationship with MIAF

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6,7 +6,7 @@ Shortname: av1-avif
 Editor: Cyril Concolato, Netflix, cconcolato@netflix.com
 Editor: Anders Klemets, Microsoft, Anders.Klemets@microsoft.com
 Former Editor: Paul Kerr, Netflix, pkerr@netflix.com
-Abstract: This document specifies syntax and semantics for the storage of [[!AV1]] images in the generic image file format [[!HEIF]], which is based on [[!ISOBMFF]]. While [[!HEIF]] defines general requirements, this document also specifies additional constraints to ensure higher interoperability between writers and readers when [[!HEIF]] is used with [[!AV1]] images. These constraints are defined in the form of profiles that extend the Multi-Image Application Format [[!MIAF]].
+Abstract: This document specifies syntax and semantics for the storage of [[!AV1]] images in the generic image file format [[!HEIF]], which is based on [[!ISOBMFF]]. While [[!HEIF]] defines general requirements, this document also specifies additional constraints to ensure higher interoperability between writers and readers when [[!HEIF]] is used with [[!AV1]] images. These constraints are based on constraints defined in the Multi-Image Application Format [[!MIAF]] and are grouped into profiles inspired by the profiles defined in [[!MIAF]].
 Date: 2018-10-11
 Repository: AOMediaCodec/av1-avif
 Inline Github Issues: full

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 018be3f805d3272ce699a232398d6e3902d1ea8d" name="generator">
   <link href="https://AOMediaCodec.github.io/av1-avif" rel="canonical">
-  <meta content="abbb6dde5b07117e1763b8ac04dd8eacb52a06aa" name="document-revision">
+  <meta content="a71ccb1ed3b409db99ef7c8e12c5d4bdf07b0cbb" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1440,7 +1440,7 @@ THE OTHER MEMBER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </p>
   </div>
   <div class="p-summary" data-fill-with="abstract">
    <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
-   <p>This document specifies syntax and semantics for the storage of <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> images in the generic image file format <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a>, which is based on <a data-link-type="biblio" href="#biblio-isobmff">[ISOBMFF]</a>. While <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a> defines general requirements, this document also specifies additional constraints to ensure higher interoperability between writers and readers when <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a> is used with <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> images. These constraints are defined in the form of profiles that extend the Multi-Image Application Format <a data-link-type="biblio" href="#biblio-miaf">[MIAF]</a>.</p>
+   <p>This document specifies syntax and semantics for the storage of <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> images in the generic image file format <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a>, which is based on <a data-link-type="biblio" href="#biblio-isobmff">[ISOBMFF]</a>. While <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a> defines general requirements, this document also specifies additional constraints to ensure higher interoperability between writers and readers when <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a> is used with <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> images. These constraints are based on constraints defined in the Multi-Image Application Format <a data-link-type="biblio" href="#biblio-miaf">[MIAF]</a> and are grouped into profiles inspired by the profiles defined in <a data-link-type="biblio" href="#biblio-miaf">[MIAF]</a>.</p>
   </div>
   <div data-fill-with="at-risk"></div>
   <nav data-fill-with="table-of-contents" id="toc">


### PR DESCRIPTION
The idea is to replace 'extend' because I find it confusing to extend MIAF given that MIAF is MPEG and based on AVC/HEVC. I wanted to say that we reuse the constraints defined in MIAF and that we followed the approach of MIAF to define AV1-based profiles.