### PR TITLE
Various editorial changes on brands

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -37,11 +37,15 @@ THE OTHER MEMBER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 </div>
 
 <pre class="anchors">
-url: http://iso.org/#; spec: HEIF; type: property;
+url: http://iso.org/#; spec: HEIF; type: dfn;
     text: coded image
     text: coded image item
-    text: colr
     text: image item
+
+url: http://iso.org/#; spec: HEIF; type: property;
+    text: colr
+    text: mif1
+    text: msf1
     text: pasp
     text: pict
     text: pixi
@@ -50,6 +54,7 @@ url: http://iso.org/#; spec: ISOBMFF; type: dfn;
     text: compatible_brands
     text: FileTypeBox
     text: major_brand
+    text: TrackTypeBox
 
 url: http://iso.org/#; spec: ISOBMFF; type: property;
     text: sync
@@ -93,17 +98,6 @@ New Image Formats and Brands" of [[!HEIF]].
 This specification reuses syntax and semantics used in [[!AV1-ISOBMFF]].
 
 ISSUE: Should this specification also define a structural brand stricter than 'miaf' to profile out some features?
-
-
-<!--h2 id="file-brand">Brands</h2>
-
-<p>This specification defines [[ISOBMFF]] brands to enable signaling that a file contains AVIF elements.</p>
-
-<p>A file declaring the brand <code><dfn>av1i</dfn></code> in the FileTypeBox SHALL contain at least one [=AV1 Image Item=] or [=AV1 Image Sequence=].</p>
-
-<p>An AVIF file containing an [=AV1 Image Item=] SHALL list the <code>mif1</code> brand as one of the entries in the <code>compatible_brands</code> array and conform to clauses 6 and 10.2 of [[!HEIF]].
-
-<p>An AVIF file containing an [=AV1 Image Sequence=] SHALL list the <code>msf1</code> brand as one of the entries in the <code>compatible_brands</code> array and conform to sections 7 and 10.3 of [[!HEIF]].</p-->
 
 <h2 id="image-item-and-properties">Image Items and properties</h2>
 
@@ -162,17 +156,21 @@ In general, it is recommended to use properties instead of [=Metadata OBUs=] in 
   <h2 id="brands-and-file-extensions">Brands and file extensions</h2>
 
 <h3 id="image-and-image-collection-brand">AVIF image and image collection brand</h3>
-Files that conform with the profile-independent restrictions in this document (sections [[#image-item-and-properties]] and [[#alpha-images]]) should include the brand
-<dfn value="" export="" for="AVIF Image brand">avif</dfn> in the [=compatible_brands=] field of the [=FileTypeBox=].
-<p>Files should also carry a compatible brand to identify the AVIF profile (see section [[#profiles]]), if any, with which the file complies.</p>
-<p>If <code>avif</code> is specified in the major_brand field of the FileTypeBox, the file extension should be ".avif".
+Files that conform with the profile-independent restrictions in this document (sections [[#image-item-and-properties]] and [[#alpha-images]]) should include in the [=compatible_brands=] field of the [=FileTypeBox=]:
+- the brand <dfn value="" export="" for="AVIF Image brand">avif</dfn> ,
+- the brand 'mif1' as recommended in [[!HEIF]],
+- a brand to identify the AVIF profile (see section [[#profiles]]), if any, with which the file complies.
+
+<p>If the brand <code>avif</code> is specified in the <code>major_brand</code> field of the [=FileTypeBox=], the file extension should be ".avif".
 The MIME Content Type for files with the ".avif" file extension shall be "image/avif".</p>
 
 <h3 id="image-sequence-brand">AVIF image sequence brand</h3>
-Files which contain one or more image sequences, and which conform with the profile-independent restrictions in this document (sections [[#image-item-and-properties]], [[#image-sequences]] and [[#alpha-images]]), should include the brand
-<dfn value="" export="" for="AVIF Image Sequence brand">avis</dfn> in the [=compatible_brands=] field of the [=FileTypeBox=].
-<p>Files should also carry a compatible brand to identify the AVIF profile (see section [[#profiles]]), if any, with which the file complies.</p>
-<p>If <code>avis</code> is specified in the major_brand field of the FileTypeBox, the file extension should be ".avifs".
+Files which contain one or more image sequences, and which conform with the profile-independent restrictions in this document (sections [[#image-item-and-properties]], [[#image-sequences]] and [[#alpha-images]]), should include in the [=compatible_brands=] field of the [=FileTypeBox=]:
+- the brand <dfn value="" export="" for="AVIF Image Sequence brand">avis</dfn>,
+- the brand 'msf1' as recommended in [[!HEIF]],
+- a brand to identify the AVIF profile (see section [[#profiles]]), if any, with which the file complies.
+
+<p>If <code>avis</code> is specified in the <code>major_brand</code> field of the [=FileTypeBox=], the file extension should be ".avifs".
 The MIME Content Type for files with the ".avifs" file extension shall be "image/avif-sequence".</p>
 
   <h2 id="profiles">Profiles</h2>
@@ -190,7 +188,7 @@ The MIME Content Type for files with the ".avifs" file extension shall be "image
 
 This section defines the MIAF AV1 Baseline profile of [[!HEIF]], specifically for [[!AV1]] bitstreams, based on the constraints specified in [[!MIAF]] and identified by the brand  <dfn value export for="AV1 Image Item Type">MA1B</dfn>.
 
-If the brand <code>MA1B</code> is in the list of [=compatible_brands=] of a TrackTypeBox or [=FileTypeBox=], the common constraints in the Profiles and brands section shall apply.
+If the brand <code>MA1B</code> is in the list of [=compatible_brands=] of a [=TrackTypeBox=] or [=FileTypeBox=], the common constraints in the Profiles and brands section shall apply.
 
   The following additional constraints apply to all [=AV1 Image Items=] and all [=AV1 Image Sequences=]:
   - The AV1 profile shall be the Main Profile and the level shall be 5.1 or lower.
@@ -202,11 +200,22 @@ NOTE:  AV1 tiers are not constrained because timing is optional in image sequenc
 
 NOTE:  Level 5.1 is chosen for the Baseline profile to ensure that no single coded image exceeds 4k resolution, as some decoder may not be able to handle larger images. It is still possible to use Baseline profile to create larger images using grid derivation.
 
+<div class="example">
+A file containing items compliant with this profile is expected to list the following brands, in any order, in the [=compatible_brands=] of the [=FileTypeBox=]:
+
+  <code>avif, mif1, miaf, MA1B</code>
+
+A file containing a 'pict' track compliant with this profile is expected to list the following brands, in any order, in the [=compatible_brands=] of the [=FileTypeBox=]:
+
+  <code>avis, msf1, miaf, MA1B</code>
+
+</div>
+
   <h3 id="advanced-profile">AVIF Advanced Profile</h3>
 
 This section defines the MIAF AV1 Advanced profile of [[!HEIF]], specifically for [[!AV1]] bitstreams, based on the constraints specified in [[!MIAF]] and identified by the brand  <dfn value="" export="" for="AV1 Image Item Type">MA1A</dfn>.
 
-If the brand <code>MA1A</code> is in the list of [=compatible_brands=] of a TrackTypeBox or [=FileTypeBox=], the common constraints in the Profiles and brands section shall apply.
+If the brand <code>MA1A</code> is in the list of [=compatible_brands=] of a =[TrackTypeBox=] or [=FileTypeBox=], the common constraints in the Profiles and brands section shall apply.
 
 The following additional constraints apply to all [=AV1 Image Items=] and all [=AV1 Image Sequences=]:
 - The AV1 profile shall be the High Profile and the level shall be 6.0 or lower.
@@ -215,3 +224,13 @@ The following additional constraints apply only to [=AV1 Image Sequences=]:
 - The AV1 profile level shall be either Main Profile or High Profile.
 - The AV1 level for Main Profile shall be 5.1 or lower.
 - The AV1 level for High Profile shall be 5.1 or lower.
+
+<div class="example">
+A file containing items compliant with this profile is expected to list the following brands, in any order, in the [=compatible_brands=] of the [=FileTypeBox=]:
+
+  <code>avif, mif1, miaf, MA1A</code>
+
+A file containing a 'pict' track compliant with this profile is expected to list the following brands, in any order, in the [=compatible_brands=] of the [=FileTypeBox=]:
+
+  <code>avis, msf1, miaf, MA1A</code>
+</div>

--- a/index.bs
+++ b/index.bs
@@ -188,7 +188,7 @@ The MIME Content Type for files with the ".avifs" file extension shall be "image
 
 This section defines the MIAF AV1 Baseline profile of [[!HEIF]], specifically for [[!AV1]] bitstreams, based on the constraints specified in [[!MIAF]] and identified by the brand  <dfn value export for="AV1 Image Item Type">MA1B</dfn>.
 
-If the brand <code>MA1B</code> is in the list of [=compatible_brands=] of a [=TrackTypeBox=] or [=FileTypeBox=], the common constraints in the Profiles and brands section shall apply.
+If the brand <code>MA1B</code> is in the list of [=compatible_brands=] of a [=TrackTypeBox=] or [=FileTypeBox=], the common constraints in the section [[#brands-and-file-extensions]] shall apply.
 
   The following additional constraints apply to all [=AV1 Image Items=] and all [=AV1 Image Sequences=]:
   - The AV1 profile shall be the Main Profile and the level shall be 5.1 or lower.
@@ -215,7 +215,7 @@ A file containing a 'pict' track compliant with this profile is expected to list
 
 This section defines the MIAF AV1 Advanced profile of [[!HEIF]], specifically for [[!AV1]] bitstreams, based on the constraints specified in [[!MIAF]] and identified by the brand  <dfn value="" export="" for="AV1 Image Item Type">MA1A</dfn>.
 
-If the brand <code>MA1A</code> is in the list of [=compatible_brands=] of a =[TrackTypeBox=] or [=FileTypeBox=], the common constraints in the Profiles and brands section shall apply.
+If the brand <code>MA1A</code> is in the list of [=compatible_brands=] of a =[TrackTypeBox=] or [=FileTypeBox=], the common constraints in the section [[#brands-and-file-extensions]] shall apply.
 
 The following additional constraints apply to all [=AV1 Image Items=] and all [=AV1 Image Sequences=]:
 - The AV1 profile shall be the High Profile and the level shall be 6.0 or lower.

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 018be3f805d3272ce699a232398d6e3902d1ea8d" name="generator">
   <link href="https://AOMediaCodec.github.io/av1-avif" rel="canonical">
-  <meta content="abbb6dde5b07117e1763b8ac04dd8eacb52a06aa" name="document-revision">
+  <meta content="a71ccb1ed3b409db99ef7c8e12c5d4bdf07b0cbb" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1557,14 +1557,28 @@ Quantity:                 One for an image item of type 'av01'
    <p>In <a data-link-type="biblio" href="#biblio-isobmff">[ISOBMFF]</a> or <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a> files, if an <a data-link-type="dfn" href="#av1-alpha-image-item" id="ref-for-av1-alpha-image-item">AV1 Alpha Image Item</a> (respectively. an <a data-link-type="dfn" href="#av1-alpha-image-sequence" id="ref-for-av1-alpha-image-sequence">AV1 Alpha Image Sequence</a>) is used, the <code>aux_type</code> field of the <code>AuxiliaryTypeProperty</code> (respectively <code>AuxiliaryTypeInfoBox</code>) shall be set to <code>urn:mpeg:mpegB:cicp:systems:auxiliary:alpha</code>, as defined in <a data-link-type="biblio" href="#biblio-miaf">[MIAF]</a>.</p>
    <h2 class="heading settled" data-level="5" id="brands-and-file-extensions"><span class="secno">5. </span><span class="content">Brands and file extensions</span><a class="self-link" href="#brands-and-file-extensions"></a></h2>
    <h3 class="heading settled" data-level="5.1" id="image-and-image-collection-brand"><span class="secno">5.1. </span><span class="content">AVIF image and image collection brand</span><a class="self-link" href="#image-and-image-collection-brand"></a></h3>
-    Files that conform with the profile-independent restrictions in this document (sections <a href="#image-item-and-properties">§2 Image Items and properties</a> and <a href="#alpha-images">§4 Alpha Image Items and Sequences</a>) should include the brand <dfn class="css" data-dfn-for="AVIF Image brand" data-dfn-type="value" data-export id="valdef-avif-image-brand-avif">avif<a class="self-link" href="#valdef-avif-image-brand-avif"></a></dfn> in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-③⓪">compatible_brands</a> field of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-③①">FileTypeBox</a>. 
-   <p>Files should also carry a compatible brand to identify the AVIF profile (see section <a href="#profiles">§6 Profiles</a>), if any, with which the file complies.</p>
-   <p>If <code>avif</code> is specified in the major_brand field of the FileTypeBox, the file extension should be ".avif".
+    Files that conform with the profile-independent restrictions in this document (sections <a href="#image-item-and-properties">§2 Image Items and properties</a> and <a href="#alpha-images">§4 Alpha Image Items and Sequences</a>) should include in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-③⓪">compatible_brands</a> field of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-③①">FileTypeBox</a>: 
+   <ul>
+    <li data-md>
+     <p>the brand <dfn class="css" data-dfn-for="AVIF Image brand" data-dfn-type="value" data-export id="valdef-avif-image-brand-avif">avif<a class="self-link" href="#valdef-avif-image-brand-avif"></a></dfn> ,</p>
+    <li data-md>
+     <p>the brand <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-③②">mif1</a> as recommended in <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a>,</p>
+    <li data-md>
+     <p>a brand to identify the AVIF profile (see section <a href="#profiles">§6 Profiles</a>), if any, with which the file complies.</p>
+   </ul>
+   <p>If the brand <code>avif</code> is specified in the <code>major_brand</code> field of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-③③">FileTypeBox</a>, the file extension should be ".avif".
 The MIME Content Type for files with the ".avif" file extension shall be "image/avif".</p>
    <h3 class="heading settled" data-level="5.2" id="image-sequence-brand"><span class="secno">5.2. </span><span class="content">AVIF image sequence brand</span><a class="self-link" href="#image-sequence-brand"></a></h3>
-    Files which contain one or more image sequences, and which conform with the profile-independent restrictions in this document (sections <a href="#image-item-and-properties">§2 Image Items and properties</a>, <a href="#image-sequences">§3 Image Sequences</a> and <a href="#alpha-images">§4 Alpha Image Items and Sequences</a>), should include the brand <dfn class="css" data-dfn-for="AVIF Image Sequence brand" data-dfn-type="value" data-export id="valdef-avif-image-sequence-brand-avis">avis<a class="self-link" href="#valdef-avif-image-sequence-brand-avis"></a></dfn> in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-③②">compatible_brands</a> field of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-③③">FileTypeBox</a>. 
-   <p>Files should also carry a compatible brand to identify the AVIF profile (see section <a href="#profiles">§6 Profiles</a>), if any, with which the file complies.</p>
-   <p>If <code>avis</code> is specified in the major_brand field of the FileTypeBox, the file extension should be ".avifs".
+    Files which contain one or more image sequences, and which conform with the profile-independent restrictions in this document (sections <a href="#image-item-and-properties">§2 Image Items and properties</a>, <a href="#image-sequences">§3 Image Sequences</a> and <a href="#alpha-images">§4 Alpha Image Items and Sequences</a>), should include in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-③④">compatible_brands</a> field of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-③⑤">FileTypeBox</a>: 
+   <ul>
+    <li data-md>
+     <p>the brand <dfn class="css" data-dfn-for="AVIF Image Sequence brand" data-dfn-type="value" data-export id="valdef-avif-image-sequence-brand-avis">avis<a class="self-link" href="#valdef-avif-image-sequence-brand-avis"></a></dfn>,</p>
+    <li data-md>
+     <p>the brand <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-③⑥">msf1</a> as recommended in <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a>,</p>
+    <li data-md>
+     <p>a brand to identify the AVIF profile (see section <a href="#profiles">§6 Profiles</a>), if any, with which the file complies.</p>
+   </ul>
+   <p>If <code>avis</code> is specified in the <code>major_brand</code> field of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-③⑦">FileTypeBox</a>, the file extension should be ".avifs".
 The MIME Content Type for files with the ".avifs" file extension shall be "image/avif-sequence".</p>
    <h2 class="heading settled" data-level="6" id="profiles"><span class="secno">6. </span><span class="content">Profiles</span><a class="self-link" href="#profiles"></a></h2>
    <p>The profiles defined in this section are for enabling interoperability between <a data-link-type="dfn" href="#av1-image-file-format" id="ref-for-av1-image-file-format②">AV1 Image File Format</a> files and <a data-link-type="dfn" href="#av1-image-file-format" id="ref-for-av1-image-file-format③">AV1 Image File Format</a> readers/parsers.
@@ -1574,13 +1588,13 @@ The MIME Content Type for files with the ".avifs" file extension shall be "image
    <p>The following constraints are common to all profiles defined in this specification:</p>
    <ul>
     <li data-md>
-     <p>The file shall be compliant with the <a data-link-type="biblio" href="#biblio-miaf">[MIAF]</a> specification and list <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-③④">miaf</a> in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-③⑤">compatible_brands</a> field of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-③⑥">FileTypeBox</a>.</p>
+     <p>The file shall be compliant with the <a data-link-type="biblio" href="#biblio-miaf">[MIAF]</a> specification and list <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-③⑧">miaf</a> in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-③⑨">compatible_brands</a> field of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④⓪">FileTypeBox</a>.</p>
     <li data-md>
-     <p>The <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-③⑦">primary image</a>, or one of its alternates, shall be an <a data-link-type="dfn" href="#av1-image-item" id="ref-for-av1-image-item⑥">AV1 Image Item</a> or be a derived image that references one or more items that all are <a data-link-type="dfn" href="#av1-image-item" id="ref-for-av1-image-item⑦">AV1 Image Items</a>.</p>
+     <p>The <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④①">primary image</a>, or one of its alternates, shall be an <a data-link-type="dfn" href="#av1-image-item" id="ref-for-av1-image-item⑥">AV1 Image Item</a> or be a derived image that references one or more items that all are <a data-link-type="dfn" href="#av1-image-item" id="ref-for-av1-image-item⑦">AV1 Image Items</a>.</p>
    </ul>
    <h3 class="heading settled" data-level="6.1" id="baseline-profile"><span class="secno">6.1. </span><span class="content">AVIF Baseline Profile</span><a class="self-link" href="#baseline-profile"></a></h3>
    <p>This section defines the MIAF AV1 Baseline profile of <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a>, specifically for <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> bitstreams, based on the constraints specified in <a data-link-type="biblio" href="#biblio-miaf">[MIAF]</a> and identified by the brand <dfn class="css" data-dfn-for="AV1 Image Item Type" data-dfn-type="value" data-export id="valdef-av1-image-item-type-ma1b">MA1B<a class="self-link" href="#valdef-av1-image-item-type-ma1b"></a></dfn>.</p>
-   <p>If the brand <code>MA1B</code> is in the list of <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-③⑧">compatible_brands</a> of a TrackTypeBox or <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-③⑨">FileTypeBox</a>, the common constraints in the Profiles and brands section shall apply.</p>
+   <p>If the brand <code>MA1B</code> is in the list of <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④②">compatible_brands</a> of a <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④③">TrackTypeBox</a> or <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④④">FileTypeBox</a>, the common constraints in the Profiles and brands section shall apply.</p>
    <p>The following additional constraints apply to all <a data-link-type="dfn" href="#av1-image-item" id="ref-for-av1-image-item⑧">AV1 Image Items</a> and all <a data-link-type="dfn" href="#av1-image-sequence" id="ref-for-av1-image-sequence②">AV1 Image Sequences</a>:</p>
    <ul>
     <li data-md>
@@ -1593,9 +1607,15 @@ The MIME Content Type for files with the ".avifs" file extension shall be "image
    </ul>
    <p class="note" role="note"><span>NOTE:</span> AV1 tiers are not constrained because timing is optional in image sequences and are not relevant in image items or collections.</p>
    <p class="note" role="note"><span>NOTE:</span> Level 5.1 is chosen for the Baseline profile to ensure that no single coded image exceeds 4k resolution, as some decoder may not be able to handle larger images. It is still possible to use Baseline profile to create larger images using grid derivation.</p>
+   <div class="example" id="example-4a96d1f5">
+    <a class="self-link" href="#example-4a96d1f5"></a> A file containing items compliant with this profile is expected to list the following brands, in any order, in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④⑤">compatible_brands</a> of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④⑥">FileTypeBox</a>: 
+    <p><code>avif, mif1, miaf, MA1B</code></p>
+    <p>A file containing a <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-④⑦">pict</a> track compliant with this profile is expected to list the following brands, in any order, in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④⑧">compatible_brands</a> of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④⑨">FileTypeBox</a>:</p>
+    <p><code>avis, msf1, miaf, MA1B</code></p>
+   </div>
    <h3 class="heading settled" data-level="6.2" id="advanced-profile"><span class="secno">6.2. </span><span class="content">AVIF Advanced Profile</span><a class="self-link" href="#advanced-profile"></a></h3>
    <p>This section defines the MIAF AV1 Advanced profile of <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a>, specifically for <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> bitstreams, based on the constraints specified in <a data-link-type="biblio" href="#biblio-miaf">[MIAF]</a> and identified by the brand <dfn class="css" data-dfn-for="AV1 Image Item Type" data-dfn-type="value" data-export id="valdef-av1-image-item-type-ma1a">MA1A<a class="self-link" href="#valdef-av1-image-item-type-ma1a"></a></dfn>.</p>
-   <p>If the brand <code>MA1A</code> is in the list of <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④⓪">compatible_brands</a> of a TrackTypeBox or <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④①">FileTypeBox</a>, the common constraints in the Profiles and brands section shall apply.</p>
+   <p>If the brand <code>MA1A</code> is in the list of <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-⑤⓪">compatible_brands</a> of a =[TrackTypeBox=] or <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-⑤①">FileTypeBox</a>, the common constraints in the Profiles and brands section shall apply.</p>
    <p>The following additional constraints apply to all <a data-link-type="dfn" href="#av1-image-item" id="ref-for-av1-image-item⑨">AV1 Image Items</a> and all <a data-link-type="dfn" href="#av1-image-sequence" id="ref-for-av1-image-sequence④">AV1 Image Sequences</a>:</p>
    <ul>
     <li data-md>
@@ -1610,6 +1630,12 @@ The MIME Content Type for files with the ".avifs" file extension shall be "image
     <li data-md>
      <p>The AV1 level for High Profile shall be 5.1 or lower.</p>
    </ul>
+   <div class="example" id="example-e237da1f">
+    <a class="self-link" href="#example-e237da1f"></a> A file containing items compliant with this profile is expected to list the following brands, in any order, in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-⑤②">compatible_brands</a> of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-⑤③">FileTypeBox</a>: 
+    <p><code>avif, mif1, miaf, MA1A</code></p>
+    <p>A file containing a <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑤④">pict</a> track compliant with this profile is expected to list the following brands, in any order, in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-⑤⑤">compatible_brands</a> of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-⑤⑥">FileTypeBox</a>:</p>
+    <p><code>avis, msf1, miaf, MA1A</code></p>
+   </div>
   </main>
   <div data-fill-with="conformance">
    <h2 class="no-ref no-num heading settled" id="conformance"><span class="content"> Conformance</span><a class="self-link" href="#conformance"></a></h2>
@@ -1872,11 +1898,11 @@ The MIME Content Type for files with the ".avifs" file extension shall be "image
     <li><a href="#termref-for-">1. Scope</a>
     <li><a href="#termref-for-">2.1. AV1 Image Item</a>
     <li><a href="#termref-for-">2.2.2. Other Item Properties</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
-    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
     <li><a href="#termref-for-">6. Profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
-    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
+    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -1885,11 +1911,11 @@ The MIME Content Type for files with the ".avifs" file extension shall be "image
     <li><a href="#termref-for-">1. Scope</a>
     <li><a href="#termref-for-">2.1. AV1 Image Item</a>
     <li><a href="#termref-for-">2.2.2. Other Item Properties</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
-    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
     <li><a href="#termref-for-">6. Profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
-    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
+    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -1898,11 +1924,11 @@ The MIME Content Type for files with the ".avifs" file extension shall be "image
     <li><a href="#termref-for-">1. Scope</a>
     <li><a href="#termref-for-">2.1. AV1 Image Item</a>
     <li><a href="#termref-for-">2.2.2. Other Item Properties</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
-    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
     <li><a href="#termref-for-">6. Profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
-    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
+    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -1911,11 +1937,11 @@ The MIME Content Type for files with the ".avifs" file extension shall be "image
     <li><a href="#termref-for-">1. Scope</a>
     <li><a href="#termref-for-">2.1. AV1 Image Item</a>
     <li><a href="#termref-for-">2.2.2. Other Item Properties</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
-    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
     <li><a href="#termref-for-">6. Profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
-    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
+    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -1924,11 +1950,11 @@ The MIME Content Type for files with the ".avifs" file extension shall be "image
     <li><a href="#termref-for-">1. Scope</a>
     <li><a href="#termref-for-">2.1. AV1 Image Item</a>
     <li><a href="#termref-for-">2.2.2. Other Item Properties</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
-    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
     <li><a href="#termref-for-">6. Profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
-    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
+    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -1937,11 +1963,11 @@ The MIME Content Type for files with the ".avifs" file extension shall be "image
     <li><a href="#termref-for-">1. Scope</a>
     <li><a href="#termref-for-">2.1. AV1 Image Item</a>
     <li><a href="#termref-for-">2.2.2. Other Item Properties</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
-    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
     <li><a href="#termref-for-">6. Profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
-    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
+    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -1950,11 +1976,11 @@ The MIME Content Type for files with the ".avifs" file extension shall be "image
     <li><a href="#termref-for-">1. Scope</a>
     <li><a href="#termref-for-">2.1. AV1 Image Item</a>
     <li><a href="#termref-for-">2.2.2. Other Item Properties</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
-    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
     <li><a href="#termref-for-">6. Profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
-    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
+    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -1963,11 +1989,11 @@ The MIME Content Type for files with the ".avifs" file extension shall be "image
     <li><a href="#termref-for-">1. Scope</a>
     <li><a href="#termref-for-">2.1. AV1 Image Item</a>
     <li><a href="#termref-for-">2.2.2. Other Item Properties</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
-    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
     <li><a href="#termref-for-">6. Profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
-    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
+    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -1976,11 +2002,11 @@ The MIME Content Type for files with the ".avifs" file extension shall be "image
     <li><a href="#termref-for-">1. Scope</a>
     <li><a href="#termref-for-">2.1. AV1 Image Item</a>
     <li><a href="#termref-for-">2.2.2. Other Item Properties</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
-    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
     <li><a href="#termref-for-">6. Profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
-    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
+    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -1989,11 +2015,63 @@ The MIME Content Type for files with the ".avifs" file extension shall be "image
     <li><a href="#termref-for-">1. Scope</a>
     <li><a href="#termref-for-">2.1. AV1 Image Item</a>
     <li><a href="#termref-for-">2.2.2. Other Item Properties</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
-    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
     <li><a href="#termref-for-">6. Profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
-    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
+    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-">
+   <a href="http://iso.org/#">http://iso.org/#</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#termref-for-">1. Scope</a>
+    <li><a href="#termref-for-">2.1. AV1 Image Item</a>
+    <li><a href="#termref-for-">2.2.2. Other Item Properties</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
+    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">6. Profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
+    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-">
+   <a href="http://iso.org/#">http://iso.org/#</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#termref-for-">1. Scope</a>
+    <li><a href="#termref-for-">2.1. AV1 Image Item</a>
+    <li><a href="#termref-for-">2.2.2. Other Item Properties</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
+    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">6. Profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
+    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-">
+   <a href="http://iso.org/#">http://iso.org/#</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#termref-for-">1. Scope</a>
+    <li><a href="#termref-for-">2.1. AV1 Image Item</a>
+    <li><a href="#termref-for-">2.2.2. Other Item Properties</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
+    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">6. Profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
+    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-">
+   <a href="http://iso.org/#">http://iso.org/#</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#termref-for-">1. Scope</a>
+    <li><a href="#termref-for-">2.1. AV1 Image Item</a>
+    <li><a href="#termref-for-">2.2.2. Other Item Properties</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
+    <li><a href="#termref-for-">5.1. AVIF image and image collection brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">5.2. AVIF image sequence brand</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">6. Profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
+    <li><a href="#termref-for-">6.1. AVIF Baseline Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
+    <li><a href="#termref-for-">6.2. AVIF Advanced Profile</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -2020,23 +2098,27 @@ The MIME Content Type for files with the ".avifs" file extension shall be "image
     <a data-link-type="biblio">[HEIF]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-①⓪" style="color:initial">colr</span>
-     <li><span class="dfn-paneled" id="term-for-①①" style="color:initial">pasp</span>
-     <li><span class="dfn-paneled" id="term-for-①②" style="color:initial">pixi</span>
+     <li><span class="dfn-paneled" id="term-for-①①" style="color:initial">mif1</span>
+     <li><span class="dfn-paneled" id="term-for-①②" style="color:initial">msf1</span>
+     <li><span class="dfn-paneled" id="term-for-①③" style="color:initial">pasp</span>
+     <li><span class="dfn-paneled" id="term-for-①④" style="color:initial">pict</span>
+     <li><span class="dfn-paneled" id="term-for-①⑤" style="color:initial">pixi</span>
     </ul>
    <li>
     <a data-link-type="biblio">[ISOBMFF]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-①③" style="color:initial">compatible_brands</span>
-     <li><span class="dfn-paneled" id="term-for-①④" style="color:initial">filetypebox</span>
-     <li><span class="dfn-paneled" id="term-for-①⑤" style="color:initial">sync</span>
+     <li><span class="dfn-paneled" id="term-for-①⑥" style="color:initial">compatible_brands</span>
+     <li><span class="dfn-paneled" id="term-for-①⑦" style="color:initial">filetypebox</span>
+     <li><span class="dfn-paneled" id="term-for-①⑧" style="color:initial">sync</span>
+     <li><span class="dfn-paneled" id="term-for-①⑨" style="color:initial">tracktypebox</span>
     </ul>
    <li>
     <a data-link-type="biblio">[MIAF]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-①⑥" style="color:initial">clli</span>
-     <li><span class="dfn-paneled" id="term-for-①⑦" style="color:initial">mdcv</span>
-     <li><span class="dfn-paneled" id="term-for-①⑧" style="color:initial">miaf</span>
-     <li><span class="dfn-paneled" id="term-for-①⑨" style="color:initial">primary image</span>
+     <li><span class="dfn-paneled" id="term-for-②⓪" style="color:initial">clli</span>
+     <li><span class="dfn-paneled" id="term-for-②①" style="color:initial">mdcv</span>
+     <li><span class="dfn-paneled" id="term-for-②②" style="color:initial">miaf</span>
+     <li><span class="dfn-paneled" id="term-for-②③" style="color:initial">primary image</span>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 018be3f805d3272ce699a232398d6e3902d1ea8d" name="generator">
   <link href="https://AOMediaCodec.github.io/av1-avif" rel="canonical">
-  <meta content="a71ccb1ed3b409db99ef7c8e12c5d4bdf07b0cbb" name="document-revision">
+  <meta content="a2a4901f7df61579f0a1478d4d3cc1718bcc3d25" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1594,7 +1594,7 @@ The MIME Content Type for files with the ".avifs" file extension shall be "image
    </ul>
    <h3 class="heading settled" data-level="6.1" id="baseline-profile"><span class="secno">6.1. </span><span class="content">AVIF Baseline Profile</span><a class="self-link" href="#baseline-profile"></a></h3>
    <p>This section defines the MIAF AV1 Baseline profile of <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a>, specifically for <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> bitstreams, based on the constraints specified in <a data-link-type="biblio" href="#biblio-miaf">[MIAF]</a> and identified by the brand <dfn class="css" data-dfn-for="AV1 Image Item Type" data-dfn-type="value" data-export id="valdef-av1-image-item-type-ma1b">MA1B<a class="self-link" href="#valdef-av1-image-item-type-ma1b"></a></dfn>.</p>
-   <p>If the brand <code>MA1B</code> is in the list of <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④②">compatible_brands</a> of a <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④③">TrackTypeBox</a> or <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④④">FileTypeBox</a>, the common constraints in the Profiles and brands section shall apply.</p>
+   <p>If the brand <code>MA1B</code> is in the list of <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④②">compatible_brands</a> of a <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④③">TrackTypeBox</a> or <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④④">FileTypeBox</a>, the common constraints in the section <a href="#brands-and-file-extensions">§5 Brands and file extensions</a> shall apply.</p>
    <p>The following additional constraints apply to all <a data-link-type="dfn" href="#av1-image-item" id="ref-for-av1-image-item⑧">AV1 Image Items</a> and all <a data-link-type="dfn" href="#av1-image-sequence" id="ref-for-av1-image-sequence②">AV1 Image Sequences</a>:</p>
    <ul>
     <li data-md>
@@ -1615,7 +1615,7 @@ The MIME Content Type for files with the ".avifs" file extension shall be "image
    </div>
    <h3 class="heading settled" data-level="6.2" id="advanced-profile"><span class="secno">6.2. </span><span class="content">AVIF Advanced Profile</span><a class="self-link" href="#advanced-profile"></a></h3>
    <p>This section defines the MIAF AV1 Advanced profile of <a data-link-type="biblio" href="#biblio-heif">[HEIF]</a>, specifically for <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> bitstreams, based on the constraints specified in <a data-link-type="biblio" href="#biblio-miaf">[MIAF]</a> and identified by the brand <dfn class="css" data-dfn-for="AV1 Image Item Type" data-dfn-type="value" data-export id="valdef-av1-image-item-type-ma1a">MA1A<a class="self-link" href="#valdef-av1-image-item-type-ma1a"></a></dfn>.</p>
-   <p>If the brand <code>MA1A</code> is in the list of <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-⑤⓪">compatible_brands</a> of a =[TrackTypeBox=] or <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-⑤①">FileTypeBox</a>, the common constraints in the Profiles and brands section shall apply.</p>
+   <p>If the brand <code>MA1A</code> is in the list of <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-⑤⓪">compatible_brands</a> of a =[TrackTypeBox=] or <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-⑤①">FileTypeBox</a>, the common constraints in the section <a href="#brands-and-file-extensions">§5 Brands and file extensions</a> shall apply.</p>
    <p>The following additional constraints apply to all <a data-link-type="dfn" href="#av1-image-item" id="ref-for-av1-image-item⑨">AV1 Image Items</a> and all <a data-link-type="dfn" href="#av1-image-sequence" id="ref-for-av1-image-sequence④">AV1 Image Sequences</a>:</p>
    <ul>
     <li data-md>


### PR DESCRIPTION
removing commented text
restructuring brand requirements as bullet points
clarifying use of HEIF brands
adding examples

It has conflicts with the changes on MIME types. Will fix them once #25 is merged.