### PR TITLE
Fix transposed characters in TrackTypeBox link

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -280,7 +280,7 @@ A file containing a 'pict' track compliant with this profile and made only of sa
 
 This section defines the MIAF AV1 Advanced profile of [[!HEIF]], specifically for [[!AV1]] bitstreams, based on the constraints specified in [[!MIAF]] and identified by the brand  <dfn value="" export="" for="AV1 Image Item Type">MA1A</dfn>.
 
-If the brand <code>MA1A</code> is in the list of [=compatible_brands=] of a =[TrackTypeBox=] or [=FileTypeBox=], the common constraints in the section [[#brands]] shall apply.
+If the brand <code>MA1A</code> is in the list of [=compatible_brands=] of a [=TrackTypeBox=] or [=FileTypeBox=], the common constraints in the section [[#brands]] shall apply.
 
 The following additional constraints apply to all [=AV1 Image Items=] and all [=AV1 Image Sequences=]:
 - The AV1 profile shall be the High Profile and the level shall be 6.0 or lower.


### PR DESCRIPTION
Also, add a newline at the end, because the Github does that automatically


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/baumanj/av1-avif/pull/66.html" title="Last updated on Dec 20, 2019, 8:29 PM UTC (41f22f5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-avif/66/9be5a5a...baumanj:41f22f5.html" title="Last updated on Dec 20, 2019, 8:29 PM UTC (41f22f5)">Diff</a>