### PR TITLE
Correct usage of level vs. level index

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -359,7 +359,7 @@ NOTE: As defined in [[!MIAF]], a file that is primarily an image sequence still 
 
   It is possible for a file compliant to this [=AV1 Image File Format=] to not be able to declare an AVIF profile, if the corresponding AV1 encoding characteristics do not match any of the defined profiles.
 
-  NOTE: [[!AV1]] supports 3 bit depths: 8, 10 and 12 bits, and the maximum dimensions of a coded image is 65536x65536, when coded with level 31.
+  NOTE: [[!AV1]] supports 3 bit depths: 8, 10 and 12 bits, and the maximum dimensions of a coded image is 65536x65536, when `seq_level_idx` is set to 31 (maximum parameters level).
 
   <div class="example">If an image is encoded with dimensions (respectively a bit depth) that exceed the maximum dimensions (respectively bit depth) required by the AV1 profile and level of the AVIF profiles defined in this specification, the file will only signal general AVIF brands.</div>
 


### PR DESCRIPTION
For consistency with the remainder of the document, this clarifies a single instance where "level" is used to refer to a `seq_level_idx` value which maps to the "maximum parameters" level.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rzumer/av1-avif/pull/135.html" title="Last updated on Mar 16, 2021, 9:53 PM UTC (cc1fbf2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-avif/135/7536f4b...rzumer:cc1fbf2.html" title="Last updated on Mar 16, 2021, 9:53 PM UTC (cc1fbf2)">Diff</a>