### PR TITLE
Make a1op a simple box

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -257,7 +257,7 @@ An <dfn>OperatingPointSelectorProperty</dfn> may be associated with an [=AV1 Ima
 <h6 id ="operating-point-selector-property-syntax" class="no-toc">Syntax</h6>
 
 ```
-class OperatingPointSelectorProperty extends ItemFullProperty('a1op', version = 0, flags) {
+class OperatingPointSelectorProperty extends ItemProperty('a1op') {
     u8 op_index;
 }
 ```

--- a/index.bs
+++ b/index.bs
@@ -446,6 +446,7 @@ A file containing a 'pict' track compliant with this profile is expected to list
 <p>The media type <code>"image/avif"</code> is officially registered with IANA and available at: <a href="https://www.iana.org/assignments/media-types/image/avif">https://www.iana.org/assignments/media-types/image/avif</a>.</p>
 
   <h2 id="change-list">Changes since v1.0.0 release</h2>
+- <a href="https://github.com/AOMediaCodec/av1-avif/pull/146">Update a1op to simple box.</a>
 - <a href="https://github.com/AOMediaCodec/av1-avif/pull/143">Update a1lx property syntax and semantics.</a>
 - <a href="https://github.com/AOMediaCodec/av1-avif/pull/145">Clarify ispe semantics.</a>
 - <a href="https://github.com/AOMediaCodec/av1-avif/pull/144">Update use of essential field for av1C.</a>

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 872cce6d3026423d677f3bd5837f1a1a46299a04" name="generator">
   <link href="https://AOMediaCodec.github.io/av1-avif" rel="canonical">
-  <meta content="781b787ea20096265b526c40575c1c820edd1531" name="document-revision">
+  <meta content="5738ba323466930b7c8a96cf443182b7b21cfbb1" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1747,6 +1747,8 @@ Quantity:       Zero or one
    <p>The media type <code>"image/avif"</code> is officially registered with IANA and available at: <a href="https://www.iana.org/assignments/media-types/image/avif">https://www.iana.org/assignments/media-types/image/avif</a>.</p>
    <h2 class="heading settled" data-level="9" id="change-list"><span class="secno">9. </span><span class="content">Changes since v1.0.0 release</span><a class="self-link" href="#change-list"></a></h2>
    <ul>
+    <li data-md>
+     <p><a href="https://github.com/AOMediaCodec/av1-avif/pull/146">Update a1op to simple box.</a></p>
     <li data-md>
      <p><a href="https://github.com/AOMediaCodec/av1-avif/pull/143">Update a1lx property syntax and semantics.</a></p>
     <li data-md>

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 872cce6d3026423d677f3bd5837f1a1a46299a04" name="generator">
   <link href="https://AOMediaCodec.github.io/av1-avif" rel="canonical">
-  <meta content="7ee4a1432d77d75042da68059569152685630bf4" name="document-revision">
+  <meta content="781b787ea20096265b526c40575c1c820edd1531" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1601,7 +1601,7 @@ Quantity:       Zero or one
    <h6 class="no-toc heading settled" data-level="2.3.2.1.2" id="operating-point-selector-property-description"><span class="secno">2.3.2.1.2. </span><span class="content">Description</span><a class="self-link" href="#operating-point-selector-property-description"></a></h6>
    <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="operatingpointselectorproperty">OperatingPointSelectorProperty</dfn> may be associated with an <a data-link-type="dfn" href="#av1-image-item" id="ref-for-av1-image-item①①">AV1 Image Item</a> to provide the index of the operating point to be processed for this item. If associated, it shall be marked as essential.</p>
    <h6 class="no-toc heading settled" data-level="2.3.2.1.3" id="operating-point-selector-property-syntax"><span class="secno">2.3.2.1.3. </span><span class="content">Syntax</span><a class="self-link" href="#operating-point-selector-property-syntax"></a></h6>
-<pre>class OperatingPointSelectorProperty extends ItemFullProperty('a1op', version = 0, flags) {
+<pre>class OperatingPointSelectorProperty extends ItemProperty('a1op') {
     u8 op_index;
 }
 </pre>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-avif/pull/147.html" title="Last updated on Apr 28, 2021, 5:04 PM UTC (e4515a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-avif/147/781b787...e4515a6.html" title="Last updated on Apr 28, 2021, 5:04 PM UTC (e4515a6)">Diff</a>