### PR TITLE
Fix "anchor defined with local link" Bikeshed err

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -66,7 +66,7 @@ Metadata Order: This version, !*, *
 
 
 <pre class="anchors">
-url: #biblio-heif; spec: HEIF; type: property;
+url: https://www.iso.org/standard/66067.html; spec: HEIF; type: property;
     text: colr
     text: mif1
     text: msf1
@@ -79,12 +79,12 @@ url: #biblio-heif; spec: HEIF; type: property;
     text: image_width
     text: image_height
 
-url: #biblio-isobmff; spec: ISOBMFF; type: dfn;
+url: https://www.iso.org/standard/68960.html; spec: ISOBMFF; type: dfn;
     text: compatible_brands
     text: FileTypeBox
     text: major_brand
 
-url: #biblio-isobmff; spec: ISOBMFF; type: property;
+url: https://www.iso.org/standard/68960.html; spec: ISOBMFF; type: property;
     text: sync
     text: cclv
     text: clli
@@ -92,10 +92,10 @@ url: #biblio-isobmff; spec: ISOBMFF; type: property;
     text: clap
     text: iloc
 
-url: #biblio-miaf; spec: MIAF; type: property;
+url: https://www.iso.org/standard/74417.html; spec: MIAF; type: property;
     text: miaf
 
-url: #biblio-miaf; spec: MIAF; type: dfn;
+url: https://www.iso.org/standard/74417.html; spec: MIAF; type: dfn;
     text: primary image
     text: MIAF image item
     text: MIAF image sequence
@@ -103,12 +103,12 @@ url: #biblio-miaf; spec: MIAF; type: dfn;
     text: MIAF auxiliary image sequence
     text: MIAF file
 
-url: #biblio-av1-isobmff; spec: AV1-ISOBMFF; type: dfn;
+url: https://aomediacodec.github.io/av1-isobmff/; spec: AV1-ISOBMFF; type: dfn;
     text: av1codecconfigurationbox
     text: AV1 Sample
     text: AV1 Track
 
-url: #biblio-av1; spec: AV1; type: dfn;
+url: https://aomediacodec.github.io/av1-spec/av1-spec.pdf; spec: AV1; type: dfn;
     text: AV1 bitstream
     text: AV1 Frame
     text: Sequence Header OBU
@@ -117,7 +117,7 @@ url: #biblio-av1; spec: AV1; type: dfn;
     text: Operating Point
     text: Intra Frame
 
-url: #biblio-av1; spec: AV1; type: dfn;
+url: https://aomediacodec.github.io/av1-spec/av1-spec.pdf; spec: AV1; type: dfn;
     text: mono_chrome
     text: color_range
     text: still_picture


### PR DESCRIPTION
Fix `FATAL ERROR: &lt;pre class=anchors> anchor was defined with a local link '#biblio-heif'. Please use urlPrefix and/or url to define an external URL`.

(update)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Nov 23, 2022, 4:30 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FAOMediaCodec%2Fav1-avif%2Fbde4abda08b7934e7b78da2de4d1f7b1157f4548%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: &lt;pre class=anchors> anchor was defined with a local link '#biblio-heif'. Please use urlPrefix and/or url to define an external URL.
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20AOMediaCodec/av1-avif%23205.)._
</details>
