### PR TITLE
Bit Depth Extension

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -304,16 +304,38 @@ NOTE: The size of the last layer can be determined by subtracting the sum of the
     - If multiple [=Sequence Header OBUs=] are present in the track payload, they shall be identical.
 
     <h2 id="auxiliary-images">Auxiliary Image Items and Sequences</h2>
-<p>An <dfn>AV1 Auxiliary Image Item</dfn> (respectively an <dfn>AV1 Auxiliary Image Sequence</dfn>) is an [=AV1 Image Item=] (respectively [=AV1 Image Sequence=]</dfn>) with the following additional constraints:
-    - It shall be a compliant [=MIAF Auxiliary Image Item=] (respectively [=MIAF Auxiliary Image Sequence=]).
+<p>An <dfn>AV1 Auxiliary Image Item</dfn> (respectively an <dfn>AV1 Auxiliary Image Sequence</dfn>) is an [=AV1 Image Item=] (respectively [=AV1 Image Sequence=]</dfn>) with the following additional constraint:
+    - It shall be a compliant [=MIAF Auxiliary Image Item=] (respectively [=MIAF Auxiliary Image Sequence=]).</p>
+
+<p>An <dfn export="">AV1 Alpha Image Item</dfn> (respectively an <dfn export="">AV1 Alpha Image Sequence</dfn>) is an [=AV1 Auxiliary Image Item=] (respectively an [=AV1 Auxiliary Image Sequence=]) with the following constraints:
+    - As defined in [[!MIAF]], the <code>aux_type</code> field of the <code>AuxiliaryTypeProperty</code> (respectively <code>AuxiliaryTypeInfoBox</code>) shall be set to <code>urn:mpeg:mpegB:cicp:systems:auxiliary:alpha</code>.
     - The <code>[=mono_chrome=]</code> field in the [=Sequence Header OBU=] shall be set to 1.
     - The <code>[=color_range=]</code> field in the [=Sequence Header OBU=] shall be set to 1.
+    - It shall be encoded with the same bit depth as the associated master [=AV1 Image Item=] (respectively [=AV1 Image Sequence=]).
+    - The ColourInformationBox should be omitted. If present, readers shall ignore it.</p>
 
-<p>An <dfn export="">AV1 Alpha Image Item</dfn> (respectively an <dfn export="">AV1 Alpha Image Sequence</dfn>) is an [=AV1 Auxiliary Image Item=] (respectively an [=AV1 Auxiliary Image Sequence=]), and as defined in [[!MIAF]], with the <code>aux_type</code> field of the <code>AuxiliaryTypeProperty</code> (respectively <code>AuxiliaryTypeInfoBox</code>) set to <code>urn:mpeg:mpegB:cicp:systems:auxiliary:alpha</code>. An <a>AV1 Alpha Image Item</a> (respectively an <a>AV1 Alpha Image Sequence</a>) shall be encoded with the same bit depth as the associated master AV1 Image Item (respectively AV1 Image Sequence).</p>
+<p>An <dfn export="">AV1 Depth Image Item</dfn> (respectively an <dfn export="">AV1 Depth Image Sequence</dfn>) is an [=AV1 Auxiliary Image Item=] (respectively an [=AV1 Auxiliary Image Sequence=]) with the following constraints:
+    - As defined in [[!MIAF]], the <code>aux_type</code> field of the <code>AuxiliaryTypeProperty</code> (respectively <code>AuxiliaryTypeInfoBox</code>) shall be set to <code>urn:mpeg:mpegB:cicp:systems:auxiliary:depth</code>.
+    - The <code>[=mono_chrome=]</code> field in the [=Sequence Header OBU=] shall be set to 1.
+    - The <code>[=color_range=]</code> field in the [=Sequence Header OBU=] shall be set to 1.</p>
 
-<p>For [=AV1 Alpha Image Item=] and [=AV1 Alpha Image Sequence=], the ColourInformationBox should be omitted. If present, readers shall ignore it.</p>
+<p>An <dfn export="">AV1 Bit Depth Extension Image Item</dfn> (respectively an <dfn export="">AV1 Bit Depth Extension Image Sequence</dfn>) is an [=AV1 Auxiliary Image Item=] (respectively an [=AV1 Auxiliary Image Sequence=]) with the following constraints:
+    - The <code>aux_type</code> field of the <code>AuxiliaryTypeProperty</code> (respectively <code>AuxiliaryTypeInfoBox</code>) shall be set to <code>urn:mpeg:mpegB:cicp:systems:auxiliary:bdex</code>.
+    - It shall be encoded with the same properties (spatial extents, number of channels etc.) as the associated master [=AV1 Image Item=] (respectively [=AV1 Image Sequence=]), except for the bit depth which may differ.
+    - If there are multiple [=AV1 Bit Depth Extension Image Items=] (respectively [=AV1 Bit Depth Extension Image Sequences=]) associated to the same master [=AV1 Image Item=] (respectively [=AV1 Image Sequence=]), readers shall apply them in the order of the association appearance in the ItemReferenceBox (respectively TrackReferenceBox).
+    - The ColourInformationBox should be omitted. If present, readers shall ignore it.
+    - The <code>aux_subtype</code> field of the <code>AuxiliaryTypeProperty</code> (respectively <code>AuxiliaryTypeInfoBox</code>) shall be set to one of the following values:
+        - <code>Xlsb</code> (<code>X</code> being an integer between <code>1</code> and <code>12</code> inclusive): Readers may extend the bit depth of the output image (respectively output sequence) by X bits, binary shift the value of all samples of the output image (respectively output sequence) by X bits to the left, and then add the X most significant bits of all samples of the decoded [=AV1 Bit Depth Extension Image Item=] (respectively [=AV1 Bit Depth Extension Image Sequence=]).
 
-<p>An <dfn export="">AV1 Depth Image Item</dfn> (respectively an <dfn export="">AV1 Depth Image Sequence</dfn>) is an [=AV1 Auxiliary Image Item=] (respectively an [=AV1 Auxiliary Image Sequence=]), and as defined in [[!MIAF]], with the <code>aux_type</code> field of the <code>AuxiliaryTypeProperty</code> (respectively <code>AuxiliaryTypeInfoBox</code>) set to <code>urn:mpeg:mpegB:cicp:systems:auxiliary:depth</code>.</p>
+            <code>X</code> shall not be greater than the bit depth of the [=AV1 Bit Depth Extension Image Item=] (respectively [=AV1 Bit Depth Extension Image Sequence=]).
+
+            Readers not applying this behavior shall ignore the [=AV1 Bit Depth Extension Image Item=] (respectively [=AV1 Bit Depth Extension Image Sequence=]) and keep the samples of the decoded master [=AV1 Image Item=] (respectively [=AV1 Image Sequence=]) as is in the output image (respectively output sequence).
+
+            <div class="example">A master [=AV1 Image Item=] with a bit depth of 12 associated to an [=AV1 Bit Depth Extension Image Item=] with an <code>aux_subtype</code> of <code>4lsb</code> may lead to an output image with a bit depth of 16 (where the 12 most significant bits of all output samples correspond to the decoded master [=AV1 Image Item=] samples and where the 4 least significant bits of all output samples correspond to the 4 most significant bits of the decoded [=AV1 Bit Depth Extension Image Item=] samples).
+
+            Otherwise, for example if the decoder does not support this Bit Depth Extension or does not need more bit depth precision than already available with the master [=AV1 Image Item=], it shall lead to an output image with a bit depth of 12 (where the 12 bits correspond to the decoded master [=AV1 Image Item=] samples).</div>
+
+            <div class="example">A master [=AV1 Image Item=] with a bit depth of 12 associated to an [=AV1 Bit Depth Extension Image Item=] with an <code>aux_subtype</code> of <code>12lsb</code> and to another [=AV1 Bit Depth Extension Image Item=] with an <code>aux_subtype</code> of <code>8lsb</code> may lead to an output image with a bit depth of 32 (where the 12 most significant bits of all output samples correspond to the decoded master [=AV1 Image Item=] samples, where the 8 least significant bits of all output samples correspond to the 8 most significant bits of the second decoded [=AV1 Bit Depth Extension Image Item=] samples and where the remaining 12 "middle" bits of all output samples correspond to the 12 most significant bits of the first decoded [=AV1 Bit Depth Extension Image Item=] samples).</div></p>
 
 NOTE: [[!AV1]] supports encoding either 3-component images (whose semantics are given by the <code>matrix_coefficients</code> element), or 1-component images (monochrome). When an image requires a different number of components, multiple auxiliary images may be used, each providing additional component(s), according to the semantics of their <code>aux_type</code> field. In such case, the maximum number of components is restricted by number of possible items in a file, coded on 16 or 32 bits.
 


### PR DESCRIPTION
Allow encoding and decoding images of more than 12 bits, the limit of the AV1 format, through a new type of auxiliary image. Define AV1 Bit Depth Extension Image Items and Sequences.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/y-guyon/av1-avif/pull/208.html" title="Last updated on Dec 1, 2022, 9:45 AM UTC (8ba03c5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-avif/208/77bd20d...y-guyon:8ba03c5.html" title="Last updated on Dec 1, 2022, 9:45 AM UTC (8ba03c5)">Diff</a>