### PR TITLE
Replace recommendations regarding still picture flags in image items by a note

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -134,8 +134,6 @@ url: https://aomediacodec.github.io/av1-spec/av1-spec.pdf; spec: AV1; type: dfn;
 url: https://aomediacodec.github.io/av1-spec/av1-spec.pdf; spec: AV1; type: dfn;
     text: mono_chrome
     text: color_range
-    text: still_picture
-    text: reduced_still_picture_header
     text: operating_points_cnt_minus_1
     text: choose_operating_point
     text: spatial_id
@@ -174,9 +172,6 @@ When an item is of type <dfn export for="AV1 Image Item Type">av01</dfn>, it is 
     - The content of an [=AV1 Image Item=] is called the <dfn export>AV1 Image Item Data</dfn> and shall obey the following constraints:
         - <assert>The [=AV1 Image Item Data=] shall be identical to the content of an [=AV1 Sample=] marked as 'sync', as defined in [[!AV1-ISOBMFF]].</assert>
         - <assert>The [=AV1 Image Item Data=] shall have exactly one [=Sequence Header OBU=].</assert>
-        - If the [=AV1 Image Item Data=] consists of a single frame (i.e. when using a single layer),
-            - <assert>It should have its <code>[=still_picture=]</code> flag set to 1.</assert>
-            - <assert>It should have its <code>[=reduced_still_picture_header=]</code> flag set to 1.</assert>
 
 <h3 id="image-item-properties">Image Item Properties</h3>
 
@@ -857,3 +852,4 @@ Other versions of the boxes shall not be used. "-" means that the box does not h
     - EDITORIAL: <a href="https://github.com/AOMediaCodec/av1-avif/pull/233">Update list of other item properties</a>
     - <a href="https://github.com/AOMediaCodec/av1-avif/pull/243">Further clarify relationship between av1C, metadata OBUs and item properties</a>
     - <a href="https://github.com/AOMediaCodec/av1-avif/pull/239">Add information on tmap, grpl and altr</a>
+    - <a href="https://github.com/AOMediaCodec/av1-avif/pull/228">Remove recommendations regarding still flags in image items.</a>

--- a/index.bs
+++ b/index.bs
@@ -130,8 +130,6 @@ url: https://aomediacodec.github.io/av1-spec/av1-spec.pdf; spec: AV1; type: dfn;
     text: Temporal Unit
     text: Operating Point
     text: Intra Frame
-
-url: https://aomediacodec.github.io/av1-spec/av1-spec.pdf; spec: AV1; type: dfn;
     text: mono_chrome
     text: color_range
     text: operating_points_cnt_minus_1
@@ -144,6 +142,8 @@ url: https://aomediacodec.github.io/av1-spec/av1-spec.pdf; spec: AV1; type: dfn;
     text: FrameHeight
     text: max_frame_width_minus1
     text: max_frame_height_minus1
+    text: still_picture
+    text: reduced_still_picture_header
 </pre>
 
 <h2 id="general">Scope</h2>

--- a/index.bs
+++ b/index.bs
@@ -173,6 +173,8 @@ When an item is of type <dfn export for="AV1 Image Item Type">av01</dfn>, it is 
         - <assert>The [=AV1 Image Item Data=] shall be identical to the content of an [=AV1 Sample=] marked as 'sync', as defined in [[!AV1-ISOBMFF]].</assert>
         - <assert>The [=AV1 Image Item Data=] shall have exactly one [=Sequence Header OBU=].</assert>
 
+NOTE: File writers may want to set the <code>[=still_picture=]</code> and <code>[=reduced_still_picture_header=]</code> flags to 1 when possible in the [=Sequence Header OBU=] part of the [=AV1 Image Item Data=] so that AV1 header overhead is minimized.
+
 <h3 id="image-item-properties">Image Item Properties</h3>
 
 <h4 id="av1-item-configuration-property">AV1 Item Configuration Property</h4>
@@ -852,4 +854,4 @@ Other versions of the boxes shall not be used. "-" means that the box does not h
     - EDITORIAL: <a href="https://github.com/AOMediaCodec/av1-avif/pull/233">Update list of other item properties</a>
     - <a href="https://github.com/AOMediaCodec/av1-avif/pull/243">Further clarify relationship between av1C, metadata OBUs and item properties</a>
     - <a href="https://github.com/AOMediaCodec/av1-avif/pull/239">Add information on tmap, grpl and altr</a>
-    - <a href="https://github.com/AOMediaCodec/av1-avif/pull/228">Remove recommendations regarding still flags in image items.</a>
+    - <a href="https://github.com/AOMediaCodec/av1-avif/pull/228">Remove recommendations regarding still picture flags in image items.</a>

--- a/index.bs
+++ b/index.bs
@@ -856,4 +856,4 @@ Other versions of the boxes shall not be used. "-" means that the box does not h
     - EDITORIAL: <a href="https://github.com/AOMediaCodec/av1-avif/pull/233">Update list of other item properties</a>
     - <a href="https://github.com/AOMediaCodec/av1-avif/pull/243">Further clarify relationship between av1C, metadata OBUs and item properties</a>
     - <a href="https://github.com/AOMediaCodec/av1-avif/pull/239">Add information on tmap, grpl and altr</a>
-    - <a href="https://github.com/AOMediaCodec/av1-avif/pull/228">Remove recommendations regarding still picture flags in image items.</a>
+    - <a href="https://github.com/AOMediaCodec/av1-avif/pull/228">Replace recommendations regarding still picture flags in image items by a note</a>

--- a/index.bs
+++ b/index.bs
@@ -130,8 +130,12 @@ url: https://aomediacodec.github.io/av1-spec/av1-spec.pdf; spec: AV1; type: dfn;
     text: Temporal Unit
     text: Operating Point
     text: Intra Frame
+
+url: https://aomediacodec.github.io/av1-spec/av1-spec.pdf; spec: AV1; type: dfn;
     text: mono_chrome
     text: color_range
+    text: still_picture
+    text: reduced_still_picture_header
     text: operating_points_cnt_minus_1
     text: choose_operating_point
     text: spatial_id
@@ -142,8 +146,6 @@ url: https://aomediacodec.github.io/av1-spec/av1-spec.pdf; spec: AV1; type: dfn;
     text: FrameHeight
     text: max_frame_width_minus1
     text: max_frame_height_minus1
-    text: still_picture
-    text: reduced_still_picture_header
 </pre>
 
 <h2 id="general">Scope</h2>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/y-guyon/av1-avif/pull/228.html" title="Last updated on Sep 17, 2024, 11:39 AM UTC (f688785)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-avif/228/3d2d175...y-guyon:f688785.html" title="Last updated on Sep 17, 2024, 11:39 AM UTC (f688785)">Diff</a>