### PR TITLE
Fix typo in av1C text discussing metadata OBUs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -185,7 +185,8 @@ The syntax and semantics of the <dfn export>AV1ItemConfigurationProperty</dfn> a
     - <assert>[=Sequence Header OBUs=] should not be present in the [=AV1CodecConfigurationBox=].</assert>
     - <assert>If a [=Sequence Header OBU=] is present in the [=AV1CodecConfigurationBox=], it shall match the [=Sequence Header OBU=] in the [=AV1 Image Item Data=].</assert>
     - <assert>The values of the fields in the [=AV1CodecConfigurationBox=] shall match those of the [=Sequence Header OBU=] in the [=AV1 Image Item Data=].</assert>
-    - <assert>[=Metadata OBUs=], if present, shall match the values given in other item properties</assert>, such as the PixelInformationProperty or ColourInformationBox.
+    - <assert>The bit depth and number of channels in the [=AV1CodecConfigurationBox=] shall match the PixelInformationProperty if present.</assert>
+    - <assert>[=Metadata OBUs=], if present, shall match the values given in other item properties</assert>, such as the MasteringDisplayColourVolumeBox or ContentLightLevelBox.
 
 <assert>This property should be marked as essential.</assert>
 
@@ -801,3 +802,4 @@ Other versions of the boxes shall not be used. "-" means that the box does not h
     - EDITORIAL: <a href="https://github.com/AOMediaCodec/av1-avif/pull/230">Fix broken link for latest-draft.html</a>
     - <a href="https://github.com/AOMediaCodec/av1-avif/pull/227">Relax constraint on transformative properties in derivation chains to only apply to grid items</a>
     - <a href="https://github.com/AOMediaCodec/av1-avif/pull/238">Change ispe width to correspond to UpscaledWidth</a>
+    - <a href="https://github.com/AOMediaCodec/av1-avif/pull/234">Clarify relationship between av1C, metadata OBUs and item properties</a>


### PR DESCRIPTION
This closes #156


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-avif/pull/234.html" title="Last updated on Sep 12, 2024, 7:32 AM UTC (7681a1c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-avif/234/7a095c1...7681a1c.html" title="Last updated on Sep 12, 2024, 7:32 AM UTC (7681a1c)">Diff</a>