### PR TITLE
Add Sample Transform rationale

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -375,7 +375,7 @@ A tone map derived image item ('tmap') as defined in [[!HEIF]] may be used in an
 
 In these sections, a "sample" refers to the value of a pixel for a given channel.
 
-With the Sample Transform file construction, pixels at the same position in multiple input image items can be aggregated into a single output pixel using basic mathematical operations. This makes it possible for [=AVIF=] to support 16 or more bits of precision per sample, while still offering backward compatibility through a regular 8 to 12-bit [=AV1 Image Item=] containing the most significant bits of each sample.
+With a Sample Transform Derived Image Item, pixels at the same position in multiple input image items can be combined into a single output pixel using basic mathematical operations. This makes it possible for [=AVIF=] to support 16 or more bits of precision per sample, while still offering backward compatibility through a regular 8 to 12-bit [=AV1 Image Item=] containing the most significant bits of each sample.
 
 <h5 id="sample-transform-definition">Definition</h5>
 

--- a/index.bs
+++ b/index.bs
@@ -375,6 +375,8 @@ A tone map derived image item ('tmap') as defined in [[!HEIF]] may be used in an
 
 In these sections, a "sample" refers to the value of a pixel for a given channel.
 
+With the Sample Transform file construction, pixels at the same position in multiple input image items can be aggregated into a single output pixel using basic mathematical operations. This makes it possible for [=AVIF=] to support 16 or more bits of precision per sample, while still offering backward compatibility through a regular 8 to 12-bit [=AV1 Image Item=] containing the most significant bits of each sample.
+
 <h5 id="sample-transform-definition">Definition</h5>
 
 When a [=derived image item=] is of type <dfn value export for="Sample Transform Derived Image Item Type">sato</dfn>, it is called a <dfn export>Sample Transform Derived Image Item</dfn>, and its reconstructed image is formed from a set of input image items, constants and operators.


### PR DESCRIPTION
Make it obvious that AVIF also supports 16-bit.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/y-guyon/av1-avif/pull/245.html" title="Last updated on Sep 18, 2024, 7:50 AM UTC (a5d301c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-avif/245/70d14e6...y-guyon:a5d301c.html" title="Last updated on Sep 18, 2024, 7:50 AM UTC (a5d301c)">Diff</a>