### PR TITLE
Use Markdown syntax coloring for code snippets

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -311,7 +311,7 @@ An <dfn export>OperatingPointSelectorProperty</dfn> may be associated with an [=
 
 <h6 id="operating-point-selector-property-syntax" class="no-toc">Syntax</h6>
 
-```
+```c
 class OperatingPointSelectorProperty extends ItemProperty('a1op') {
     unsigned int(8) op_index;
 }
@@ -345,7 +345,7 @@ The <code>[=AV1LayeredImageIndexingProperty=]</code> documents the size in bytes
 
 <h6 id="layered-image-indexing-property-syntax" class="no-toc">Syntax</h6>
 
-```
+```c
 class AV1LayeredImageIndexingProperty extends ItemProperty('a1lx') {
     unsigned int(7) reserved = 0;
     unsigned int(1) large_size;


### PR DESCRIPTION
Already done for `SampleTransform`.
I find it improves the readability of the Syntax sections.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/y-guyon/av1-avif/pull/259.html" title="Last updated on Oct 18, 2024, 9:13 AM UTC (3e9e460)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-avif/259/727501a...y-guyon:3e9e460.html" title="Last updated on Oct 18, 2024, 9:13 AM UTC (3e9e460)">Diff</a>