### PR TITLE
Use exact tokens as sato math expr example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1324,8 +1324,8 @@ Consider the following:
             - <code>[=sato/token=]</code>=130 (product)
             - <code>[=sato/token=]</code>=2 (sample from 2<sup>nd</sup> input image item)
             - <code>[=sato/token=]</code>=128 (sum)
-            - <code>[=sato/token=]</code>=0, <code>[=sato/constant=]</code>=-128
-            - <code>[=sato/token=]</code>=128 (sum)
+            - <code>[=sato/token=]</code>=0, <code>[=sato/constant=]</code>=128
+            - <code>[=sato/token=]</code>=129 (difference)
 
 This is equivalent to the following postfix notation (parentheses for clarity):
 


### PR DESCRIPTION
Fixes https://github.com/AOMediaCodec/av1-avif/issues/269.