### PR TITLE
Clarify it is the order that shall be respected

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -838,7 +838,7 @@ This section discusses the box requirements for an [=AVIF file=] containing only
 <h4 id="avif-required-boxes">Minimum set of boxes</h4>
 
 <p>As indicated in [[#file-constraints]], an [=AVIF file=] is a compliant [[!MIAF]] file. As a consequence, some [[!ISOBMFF]] or [[!HEIF]] boxes are required, as indicated in the following table. The order of the boxes is indicative in the table. The specifications listed in the "Specification" 
-column may require a specific order for the box or for its children and shall be respected. For example, per [[!ISOBMFF]], the <code>[=FileTypeBox=]</code> is required to appear first in an [=AVIF file=].
+column may require a specific order for a box or for its children and the order shall be respected. For example, per [[!ISOBMFF]], the <code>[=FileTypeBox=]</code> is required to appear first in an [=AVIF file=].
 The "Version(s)" column in the following table lists the version(s) of the boxes allowed by this brand. <assert>With the exception of item properties marked as non-essential, other versions of the boxes shall not be used.</assert> "-" means that the box does not have a version.</p>
 
 <table class="data">
@@ -985,7 +985,7 @@ The "Version(s)" column in the following table lists the version(s) of the boxes
 
 <h4 id="avif-required-boxes-additional">Requirements on additional image item related boxes</h4>
 
-<p>The boxes indicated in the following table may be present in an [=AVIF file=] to provide additional signaling for image items. The boxes may be present inside the box indicated in the "Containing Box" column. <assert>If present, they shall use the version indicated in the table unless the box is an item property marked as non-essential.</assert> [=/AVIF=] readers are expected to understand the boxes and versions listed in this table. The order of the boxes is indicative in the table. Specifications may require specific order and shall be respected. Additionally, the <code>'[=free=]'</code> and <code>'[=skip=]'</code> boxes may be present at any level in the hierarchy and [=/AVIF=] readers are expected to ignore them. Additional boxes in the <code>'[=meta=]'</code> hierarchy not listed in the following table may also be present and may be ignored by [=/AVIF=] readers.</p>
+<p>The boxes indicated in the following table may be present in an [=AVIF file=] to provide additional signaling for image items. The boxes may be present inside the box indicated in the "Containing Box" column. <assert>If present, they shall use the version indicated in the table unless the box is an item property marked as non-essential.</assert> [=/AVIF=] readers are expected to understand the boxes and versions listed in this table. The order of the boxes is indicative in the table. Specifications may require a specific order for a box or for its children and the order shall be respected. Additionally, the <code>'[=free=]'</code> and <code>'[=skip=]'</code> boxes may be present at any level in the hierarchy and [=/AVIF=] readers are expected to ignore them. Additional boxes in the <code>'[=meta=]'</code> hierarchy not listed in the following table may also be present and may be ignored by [=/AVIF=] readers.</p>
 <table class="data">
     <thead>
         <tr>


### PR DESCRIPTION
Otherwise, it seems that it is the specifications that shall be respected.

Also make the second instance of this sentence more similar to the first instance.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wantehchang/av1-avif/pull/275.html" title="Last updated on Oct 23, 2024, 3:45 PM UTC (be09d08)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-avif/275/a83f921...wantehchang:be09d08.html" title="Last updated on Oct 23, 2024, 3:45 PM UTC (be09d08)">Diff</a>