### PR TITLE
Use precise dim/chan constraints in sato examples

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1280,7 +1280,7 @@ The following example describes how to leverage a [=Sample Transform Derived Ima
 
 Consider the following:
     - A [=MIAF image item=] being a losslessly coded image item,<br>and its <code>[=PixelInformationProperty=]</code> with <code>[=bits_per_channel=]</code>=8,
-    - Another [=MIAF image item=] being a lossily or losslessly coded image item with the same dimensions and number of samples as the first input image item,<br>and its <code>[=PixelInformationProperty=]</code> with <code>[=bits_per_channel=]</code>=8,
+    - Another [=MIAF image item=] being a lossily or losslessly coded image item with the same spatial dimensions, the same number of channels, and the same chroma subsampling (or lack thereof) as the first input image item,<br>and its <code>[=PixelInformationProperty=]</code> with <code>[=bits_per_channel=]</code>=8,
     - A [=Sample Transform Derived Image Item=] with the two items above as input in this order,<br>and its <code>[=PixelInformationProperty=]</code> with <code>[=bits_per_channel=]</code>=16,<br>and the following <code>[=SampleTransform=]</code> fields:
         - <code>[=sato/version=]</code>=0
         - <code>[=sato/bit_depth=]</code>=2 (signed 32-bit <code>[=sato/constant=]</code>s, stack values and intermediate results)
@@ -1314,7 +1314,7 @@ It differs from the [[#sato-example-suffix-bit-depth-extension]] by its slightly
 
 Consider the following:
     - A [=MIAF image item=] being a lossily coded image item,<br>and its <code>[=PixelInformationProperty=]</code> with <code>[=bits_per_channel=]</code>=12,
-    - Another [=MIAF image item=] being a lossily or losslessly coded image item with the same dimensions and number of samples as the first input image item,<br>and its <code>[=PixelInformationProperty=]</code> with <code>[=bits_per_channel=]</code>=8,<br>with the following contraints:
+    - Another [=MIAF image item=] being a lossily or losslessly coded image item with the same spatial dimensions, the same number of channels, and the same chroma subsampling (or lack thereof) as the first input image item,<br>and its <code>[=PixelInformationProperty=]</code> with <code>[=bits_per_channel=]</code>=8,<br>with the following contraints:
         <li style="list-style: none"><ul><li style="list-style: none">For each sample position in each plane,<br><math><msub><mi>sample</mi><mi>original</mi></msub></math> being the value of the 16-bit original sample at that position in that plane,<br><math><msub><mi>sample</mi><mi>1</mi></msub></math> being the value of the 12-bit sample of the first input image at that position in that plane,<br><math><msub><mi>sample</mi><mi>2</mi></msub></math> being the value of the sample of the second input image at that position in that plane,<br><math><mo>≈</mo></math> representing similarity within compression loss range,</li></ul></li>
         - <math><msub><mi>sample</mi><mi>1</mi></msub><mo>≈</mo><mfrac><msub><mi>sample</mi><mi>original</mi></msub><msup><mn>2</mn><mn>4</mn></msup></mfrac></math>
         - <math><msub><mi>sample</mi><mi>2</mi></msub><mo>≈</mo><msub><mi>sample</mi><mi>original</mi></msub><mo>-</mo><msup><mn>2</mn><mn>4</mn></msup><mo>×</mo><msub><mi>sample</mi><mi>1</mi></msub><mo>+</mo><msup><mn>2</mn><mn>7</mn></msup></math>


### PR DESCRIPTION
Fixes https://github.com/AOMediaCodec/av1-avif/issues/283


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/y-guyon/av1-avif/pull/287.html" title="Last updated on Oct 23, 2024, 9:21 AM UTC (236edd2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-avif/287/439b57e...y-guyon:236edd2.html" title="Last updated on Oct 23, 2024, 9:21 AM UTC (236edd2)">Diff</a>