### PR TITLE
Gainmap and least signif should be hidden items

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -396,7 +396,7 @@ A <dfn noexport>grid derived image item</dfn> (<code>'[=grid=]'</code>) as defin
 
 <h4 id="tone-map-derivation">Tone Map Derived Image Item</h4>
 
-A <dfn noexport>tone map derived image item</dfn> (<code>'[=tmap=]'</code>) as defined in [[!HEIF]] may be used in an [=AVIF file=]. <assert>When present, the base image item and the <code>'[=tmap=]'</code> image item should be grouped together by an <code>'[=altr=]'</code> (see [[#altr-group]]) entity group as recommended in [[!HEIF]].</assert>
+A <dfn noexport>tone map derived image item</dfn> (<code>'[=tmap=]'</code>) as defined in [[!HEIF]] may be used in an [=AVIF file=]. <assert>When present, the base image item and the <code>'[=tmap=]'</code> image item should be grouped together by an <code>'[=altr=]'</code> (see [[#altr-group]]) entity group as recommended in [[!HEIF]].</assert> <assert>When present, the gainmap image item should be a hidden image item as recommended in [[!HEIF]].</assert>
 
 <h4 id="sample-transform">Sample Transform Derived Image Item</h4>
 
@@ -1359,7 +1359,7 @@ This is equivalent to the following infix notation:
 
 Each output sample is equal to the sum of a sample of the first input image item shifted to the left by 8 and of a sample of the second input image item. This can be viewed as a bit depth extension of the first input image item by the second input image item. The first input image item contains the 8 most significant bits and the second input image item contains the 8 least significant bits of the output reconstructed image item which has a bit depth of 16, something that is impossible to achieve with a single [=AV1 image item=].
 
-NOTE: If the first input image item is the [=primary image item=] and is enclosed in an <code>'[=altr=]'</code> group (see [[#altr-group]]) with the [=Sample Transform Derived Image Item=], the first input image item is also a backward-compatible 8-bit regular coded image item that can be used by readers that do not support [=Sample Transform Derived Image Items=] or do not need extra precision.
+NOTE: If the first input image item is the [=primary image item=] and is enclosed in an <code>'[=altr=]'</code> group (see [[#altr-group]]) with the [=Sample Transform Derived Image Item=], the first input image item is also a backward-compatible 8-bit regular coded image item that can be used by readers that do not support [=Sample Transform Derived Image Items=] or do not need extra precision. The second input image item should be a hidden image item as recommended in [[!HEIF]].
 
 NOTE: The second input image item loses its meaning of least significant part if any of the most significant bits changes, so the first input image item has to be losslessly encoded. The second input image item supports reasonable loss during encoding.
 
@@ -1401,7 +1401,7 @@ This is equivalent to the following infix notation:
 
 Each output sample is equal to the sum of a sample of the first input image item shifted to the left by 4 and of a sample of the second input image item offset by -128. This can be viewed as a bit depth extension of the first input image item by the second input image item which contains the residuals to correct the precision loss of the first input image item.
 
-NOTE: If the first input image item is the [=primary image item=] and is enclosed in an <code>'[=altr=]'</code> group (see [[#altr-group]]) with the derived image item, the first input image item is also a backward-compatible 12-bit regular coded image item that can be used by decoding contexts that do not support [=Sample Transform Derived Image Items=] or do not need extra precision.
+NOTE: If the first input image item is the [=primary image item=] and is enclosed in an <code>'[=altr=]'</code> group (see [[#altr-group]]) with the derived image item, the first input image item is also a backward-compatible 12-bit regular coded image item that can be used by decoding contexts that do not support [=Sample Transform Derived Image Items=] or do not need extra precision. The second input image item should be a hidden image item as recommended in [[!HEIF]].
 
 NOTE: The first input image item supports reasonable loss during encoding because the second input image item "overlaps" by 4 bits to correct the loss. The second input image item supports reasonable loss during encoding.
 

--- a/index.bs
+++ b/index.bs
@@ -1359,7 +1359,9 @@ This is equivalent to the following infix notation:
 
 Each output sample is equal to the sum of a sample of the first input image item shifted to the left by 8 and of a sample of the second input image item. This can be viewed as a bit depth extension of the first input image item by the second input image item. The first input image item contains the 8 most significant bits and the second input image item contains the 8 least significant bits of the output reconstructed image item which has a bit depth of 16, something that is impossible to achieve with a single [=AV1 image item=].
 
-NOTE: If the first input image item is the [=primary image item=] and is enclosed in an <code>'[=altr=]'</code> group (see [[#altr-group]]) with the [=Sample Transform Derived Image Item=], the first input image item is also a backward-compatible 8-bit regular coded image item that can be used by readers that do not support [=Sample Transform Derived Image Items=] or do not need extra precision. The second input image item should be a hidden image item as recommended in [[!HEIF]].
+NOTE: If the first input image item is the [=primary image item=] and is enclosed in an <code>'[=altr=]'</code> group (see [[#altr-group]]) with the [=Sample Transform Derived Image Item=], the first input image item is also a backward-compatible 8-bit regular coded image item that can be used by readers that do not support [=Sample Transform Derived Image Items=] or do not need extra precision.
+
+NOTE: The second input image item can be marked as hidden to prevent readers from surfacing it to users.
 
 NOTE: The second input image item loses its meaning of least significant part if any of the most significant bits changes, so the first input image item has to be losslessly encoded. The second input image item supports reasonable loss during encoding.
 
@@ -1401,7 +1403,9 @@ This is equivalent to the following infix notation:
 
 Each output sample is equal to the sum of a sample of the first input image item shifted to the left by 4 and of a sample of the second input image item offset by -128. This can be viewed as a bit depth extension of the first input image item by the second input image item which contains the residuals to correct the precision loss of the first input image item.
 
-NOTE: If the first input image item is the [=primary image item=] and is enclosed in an <code>'[=altr=]'</code> group (see [[#altr-group]]) with the derived image item, the first input image item is also a backward-compatible 12-bit regular coded image item that can be used by decoding contexts that do not support [=Sample Transform Derived Image Items=] or do not need extra precision. The second input image item should be a hidden image item as recommended in [[!HEIF]].
+NOTE: If the first input image item is the [=primary image item=] and is enclosed in an <code>'[=altr=]'</code> group (see [[#altr-group]]) with the derived image item, the first input image item is also a backward-compatible 12-bit regular coded image item that can be used by decoding contexts that do not support [=Sample Transform Derived Image Items=] or do not need extra precision.
+
+NOTE: The second input image item can be marked as hidden to prevent readers from surfacing it to users.
 
 NOTE: The first input image item supports reasonable loss during encoding because the second input image item "overlaps" by 4 bits to correct the loss. The second input image item supports reasonable loss during encoding.
 

--- a/index.bs
+++ b/index.bs
@@ -91,6 +91,7 @@ url: https://www.iso.org/standard/66067.html; spec: HEIF; type: dfn;
     text: derived image item
     text: dimg
     text: grid
+    text: hidden image item
     text: image_height
     text: image_width
     text: imir
@@ -269,7 +270,7 @@ NOTE: The values of <code>[=render_width_minus1=]</code> and <code>[=render_heig
 
 The semantics of the clean aperture property (<code>'[=clap=]'</code>) as defined in [[!HEIF]] apply. In addition to the restrictions on transformative item property ordering specified in [[!MIAF]], the following restriction also applies:
 
-<assert>The origin of the <code>'[=clap=]'</code> item property shall be anchored to 0,0 (top-left) of the input image unless the full, un-cropped image item is included as a secondary non-hidden image item.</assert>
+<assert>The origin of the <code>'[=clap=]'</code> item property shall be anchored to 0,0 (top-left) of the input image unless the full, un-cropped image item is included as a secondary [=hidden image item|non-hidden image item=].</assert>
 
 <h4 id="other-item-property">Other Item Properties</h4>
 
@@ -396,7 +397,7 @@ A <dfn noexport>grid derived image item</dfn> (<code>'[=grid=]'</code>) as defin
 
 <h4 id="tone-map-derivation">Tone Map Derived Image Item</h4>
 
-A <dfn noexport>tone map derived image item</dfn> (<code>'[=tmap=]'</code>) as defined in [[!HEIF]] may be used in an [=AVIF file=]. <assert>When present, the base image item and the <code>'[=tmap=]'</code> image item should be grouped together by an <code>'[=altr=]'</code> (see [[#altr-group]]) entity group as recommended in [[!HEIF]].</assert> <assert>When present, the gainmap image item should be a hidden image item as recommended in [[!HEIF]].</assert>
+A <dfn noexport>tone map derived image item</dfn> (<code>'[=tmap=]'</code>) as defined in [[!HEIF]] may be used in an [=AVIF file=]. <assert>When present, the base image item and the <code>'[=tmap=]'</code> image item should be grouped together by an <code>'[=altr=]'</code> (see [[#altr-group]]) entity group as recommended in [[!HEIF]].</assert> <assert>When present, the gainmap image item should be a [=hidden image item=].</assert>
 
 <h4 id="sample-transform">Sample Transform Derived Image Item</h4>
 
@@ -1361,7 +1362,7 @@ Each output sample is equal to the sum of a sample of the first input image item
 
 NOTE: If the first input image item is the [=primary image item=] and is enclosed in an <code>'[=altr=]'</code> group (see [[#altr-group]]) with the [=Sample Transform Derived Image Item=], the first input image item is also a backward-compatible 8-bit regular coded image item that can be used by readers that do not support [=Sample Transform Derived Image Items=] or do not need extra precision.
 
-NOTE: The second input image item can be marked as hidden to prevent readers from surfacing it to users.
+NOTE: The second input image item can be marked as [=hidden image item|hidden=] to prevent readers from surfacing it to users.
 
 NOTE: The second input image item loses its meaning of least significant part if any of the most significant bits changes, so the first input image item has to be losslessly encoded. The second input image item supports reasonable loss during encoding.
 
@@ -1405,7 +1406,7 @@ Each output sample is equal to the sum of a sample of the first input image item
 
 NOTE: If the first input image item is the [=primary image item=] and is enclosed in an <code>'[=altr=]'</code> group (see [[#altr-group]]) with the derived image item, the first input image item is also a backward-compatible 12-bit regular coded image item that can be used by decoding contexts that do not support [=Sample Transform Derived Image Items=] or do not need extra precision.
 
-NOTE: The second input image item can be marked as hidden to prevent readers from surfacing it to users.
+NOTE: The second input image item can be marked as [=hidden image item|hidden=] to prevent readers from surfacing it to users.
 
 NOTE: The first input image item supports reasonable loss during encoding because the second input image item "overlaps" by 4 bits to correct the loss. The second input image item supports reasonable loss during encoding.
 

--- a/index.bs
+++ b/index.bs
@@ -1324,6 +1324,7 @@ The "Version(s)" column in the following table lists the version(s) of the boxes
     - EDITORIAL: <a href="https://github.com/AOMediaCodec/av1-avif/pull/266">Indent notes as the list items they refer to</a>
     - EDITORIAL: <a href="https://github.com/AOMediaCodec/av1-avif/pull/267">Remove inconsistent dots in 9.1.2</a>
     - <a href="https://github.com/AOMediaCodec/av1-avif/pull/273">Change structure of optional table of boxes</a>
+    - <a href="https://github.com/AOMediaCodec/av1-avif/pull/288">Add hidden image item recommendation</a>
 
 <h2 id="sato-examples">Appendix A: (informative) Sample Transform Derived Image Item Examples</h2>
 


### PR DESCRIPTION
Fixes https://github.com/AOMediaCodec/av1-avif/issues/278


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/y-guyon/av1-avif/pull/288.html" title="Last updated on Oct 23, 2024, 11:02 AM UTC (6d9dc43)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-avif/288/7e5c8c7...y-guyon:6d9dc43.html" title="Last updated on Oct 23, 2024, 11:02 AM UTC (6d9dc43)">Diff</a>