### PR TITLE
Remove mentions of ftyp compatible_brands

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -120,7 +120,6 @@ url: https://www.iso.org/standard/68960.html; spec: ISOBMFF; type: dfn;
     text: colour_type
     text: ColourInformationBox
     text: colr
-    text: compatible_brands
     text: ContentLightLevelBox
     text: dinf
     text: dref
@@ -705,7 +704,7 @@ The <code>'[=ster=]'</code> entity group as defined in [[!HEIF]] may be used to 
 
 <h3 id="brands-overview">Brands overview</h3>
 
-<p>As defined by [[!ISOBMFF]], the presence of a brand in the <code>[=compatible_brands=]</code> list in the <code>[=FileTypeBox=]</code> can be interpreted as the permission for those [=AV1 Image File Format=] readers/parsers and [=AV1 Image File Format=] renderers that only implement the features required by the brand, to process the corresponding file and only the parts (e.g. items or sequences) that comply with the brand.</p>
+<p>As defined by [[!ISOBMFF]], the presence of a brand in the <code>[=FileTypeBox=]</code> can be interpreted as the permission for those [=AV1 Image File Format=] readers/parsers and [=AV1 Image File Format=] renderers that only implement the features required by the brand, to process the corresponding file and only the parts (e.g. items or sequences) that comply with the brand.</p>
 
 <p>An [=AV1 Image File Format=] file may conform to multiple brands. Similarly, an [=AV1 Image File Format=] reader/parser or [=AV1 Image File Format=] renderer may be capable of processing the features associated with one or more brands.</p>
 
@@ -714,32 +713,32 @@ The <code>'[=ster=]'</code> entity group as defined in [[!HEIF]] may be used to 
 <h3 id="image-and-image-collection-brand">AVIF image and image collection brand</h3>
 The brand to identify [=AV1 image items=] is <dfn export for="AVIF Image brand">avif</dfn>.
 
-Files that indicate this brand in the <code>[=compatible_brands=]</code> field of the <code>[=FileTypeBox=]</code> shall comply with the following:
+Files that indicate this brand in the <code>[=FileTypeBox=]</code> shall comply with the following:
     - <assert>The [=primary image item=] shall be an [=AV1 Image Item=] or be a derived image that references directly or indirectly one or more items that all are [=AV1 Image Items=].</assert>
     - [=AV1 auxiliary image items=] may be present in the file.
 
-<assert>Files that conform with these constraints should include the brand <code>[=AVIF Image brand/avif=]</code> in the <code>[=compatible_brands=]</code> field of the <code>[=FileTypeBox=]</code>.</assert>
+<assert>Files that conform with these constraints should include the brand <code>[=AVIF Image brand/avif=]</code> in the <code>[=FileTypeBox=]</code>.</assert>
 
-Additionally, the brand <dfn export for="AVIF Intra-only brand">avio</dfn> is defined. If the file indicates the brand <code>[=avio=]</code> in the <code>[=compatible_brands=]</code> field of the <code>[=FileTypeBox=]</code>, then <assert>the [=primary image item=] or all the items referenced by the [=primary image item=] shall be [=AV1 image items=] made only of [=Intra Frames=]</assert>. Conversely, <assert>if the previous constraint applies, the brand <code>[=avio=]</code> should be used in the <code>[=compatible_brands=]</code> field of the <code>[=FileTypeBox=]</code></assert>.
+Additionally, the brand <dfn export for="AVIF Intra-only brand">avio</dfn> is defined. If the file indicates the brand <code>[=avio=]</code> in the <code>[=FileTypeBox=]</code>, then <assert>the [=primary image item=] or all the items referenced by the [=primary image item=] shall be [=AV1 image items=] made only of [=Intra Frames=]</assert>. Conversely, <assert>if the previous constraint applies, the brand <code>[=avio=]</code> should be used in the <code>[=FileTypeBox=]</code></assert>.
 
 <h3 id="image-sequence-brand">AVIF image sequence brands</h3>
 The brand to identify [=AV1 image sequences=] is <dfn export for="AVIF Image Sequence brand">avis</dfn>.
 
-Files that indicate this brand in the <code>[=compatible_brands=]</code> field of the <code>[=FileTypeBox=]</code> shall comply with the following:
+Files that indicate this brand in the <code>[=FileTypeBox=]</code> shall comply with the following:
     - <assert>they shall contain one or more [=AV1 image sequences=].</assert>
     - they may contain [=AV1 auxiliary image sequences=].
 
-<assert>Files that conform with these constraints should include the brand <code>[=avis=]</code> in the <code>[=compatible_brands=]</code> field of the <code>[=FileTypeBox=]</code>.</assert>
+<assert>Files that conform with these constraints should include the brand <code>[=avis=]</code> in the <code>[=FileTypeBox=]</code>.</assert>
 
-Additionally, if a file contains [=AV1 image sequences=] and the brand <code>[=avio=]</code> is used in the <code>[=compatible_brands=]</code> field of the <code>[=FileTypeBox=]</code>, <assert>the item constraints for this brand shall be met</assert> and <assert>at least one of the [=AV1 image sequences=] shall be made only of [=AV1 Samples=] marked as <code>'[=sync=]'</code></assert>. Conversely, <assert>if such a track exists and the constraints of the brand <code>[=avio=]</code> on [=AV1 image items=] are met, the brand should be used</assert>.
+Additionally, if a file contains [=AV1 image sequences=] and the brand <code>[=avio=]</code> is used in the <code>[=FileTypeBox=]</code>, <assert>the item constraints for this brand shall be met</assert> and <assert>at least one of the [=AV1 image sequences=] shall be made only of [=AV1 Samples=] marked as <code>'[=sync=]'</code></assert>. Conversely, <assert>if such a track exists and the constraints of the brand <code>[=avio=]</code> on [=AV1 image items=] are met, the brand should be used</assert>.
 
 NOTE: As defined in [[!MIAF]], a file that is primarily an image sequence still has at least an image item. Hence, it can also declare brands for signaling the image item.
 
 <h2 id="file-constraints">General constraints</h2>
 
 The following constraints are common to files compliant with this specification:
-    - <assert>The file shall be compliant with the [[!MIAF]] specification and list <code>'[=miaf=]'</code> in the <code>[=compatible_brands=]</code> field of the <code>[=FileTypeBox=]</code>.</assert>
-    - <assert>The file shall list <code>'[=AVIF Image brand/avif=]'</code> or <code>'[=avis=]'</code> in the <code>[=compatible_brands=]</code> field of the <code>[=FileTypeBox=]</code>.</assert>
+    - <assert>The file shall be compliant with the [[!MIAF]] specification and list <code>'[=miaf=]'</code> in the <code>[=FileTypeBox=]</code>.</assert>
+    - <assert>The file shall list <code>'[=AVIF Image brand/avif=]'</code> or <code>'[=avis=]'</code> in the <code>[=FileTypeBox=]</code>.</assert>
     - <assert>Transformative properties shall not be associated with items in a derivation chain (as defined in [[!MIAF]]) that serves as an input to a [=grid derived image item=].</assert> For example, if a file contains a grid item and its referenced coded image items, cropping, mirroring or rotation transformations are only permitted on the grid item itself.
 
         NOTE: This constraint further restricts files compared to [[!MIAF]].
@@ -764,7 +763,7 @@ NOTE: [[!AV1]] supports 3 bit depths: 8, 10 and 12 bits, and the maximum dimensi
 
 This section defines the MIAF AV1 Baseline profile of [[!HEIF]], specifically for [[!AV1]] bitstreams, based on the constraints specified in [[!MIAF]] and identified by the brand  <dfn export for="AVIF Baseline Profile">MA1B</dfn>.
 
-If the brand <code>'[=MA1B=]'</code> is in the list of <code>[=compatible_brands=]</code> of the <code>[=FileTypeBox=]</code>, the common constraints in the section [[#brands]] shall apply.
+If the brand <code>'[=MA1B=]'</code> is in the <code>[=FileTypeBox=]</code>, the common constraints in the section [[#brands]] shall apply.
 
 The following shared conditions and requirements from [[!MIAF]] shall apply:
     - <assert>[=self-containment=] (subclause 8.2)</assert>
@@ -783,15 +782,15 @@ The following additional constraints apply to all [=AV1 Image Items=] and all [=
         NOTE:  Level 5.1 is chosen for the Baseline profile to ensure that no single coded image exceeds 4k resolution, as some decoders may not be able to handle larger images. More precisely, following [[!AV1]] level definitions, coded image items compliant to the [=AVIF Baseline profile=] may not have a number of pixels greater than 8912896, a width greater than 8192 or a height greater than 4352. It is still possible to use the Baseline profile to create larger images using a [=grid derived image item=].
 
 <div class="example">
-A file containing items compliant with this profile is expected to list the following brands, in any order, in the <code>[=compatible_brands=]</code> of the <code>[=FileTypeBox=]</code>:
+A file containing items compliant with this profile is expected to list the following brands, in any order, in the <code>[=FileTypeBox=]</code>:
 
     <code>avif, mif1, miaf, MA1B</code>
 
-A file containing a <code>'[=pict=]'</code> track compliant with this profile is expected to list the following brands, in any order, in the <code>[=compatible_brands=]</code> of the <code>[=FileTypeBox=]</code>:
+A file containing a <code>'[=pict=]'</code> track compliant with this profile is expected to list the following brands, in any order, in the <code>[=FileTypeBox=]</code>:
 
     <code>avis, msf1, miaf, MA1B</code>
 
-A file containing a <code>'[=pict=]'</code> track compliant with this profile and made only of [=AV1 Samples=] marked <code>'[=sync=]'</code> is expected to list the following brands, in any order, in the <code>[=compatible_brands=]</code> of the <code>[=FileTypeBox=]</code>:
+A file containing a <code>'[=pict=]'</code> track compliant with this profile and made only of [=AV1 Samples=] marked <code>'[=sync=]'</code> is expected to list the following brands, in any order, in the <code>[=FileTypeBox=]</code>:
 
     <code>avis, avio, msf1, miaf, MA1B</code>
 </div>
@@ -800,7 +799,7 @@ A file containing a <code>'[=pict=]'</code> track compliant with this profile an
 
 This section defines the MIAF AV1 Advanced profile of [[!HEIF]], specifically for [[!AV1]] bitstreams, based on the constraints specified in [[!MIAF]] and identified by the brand <dfn export for="AVIF Advanced Profile">MA1A</dfn>.
 
-If the brand <code>'[=MA1A=]'</code> is in the list of <code>[=compatible_brands=]</code> of the <code>[=FileTypeBox=]</code>, the common constraints in the section [[#brands]] shall apply.
+If the brand <code>'[=MA1A=]'</code> is in the <code>[=FileTypeBox=]</code>, the common constraints in the section [[#brands]] shall apply.
 
 The following shared conditions and requirements from [[!MIAF]] shall apply:
     - <assert>[=self-containment=] (subclause 8.2)</assert>
@@ -822,11 +821,11 @@ The following additional constraints apply only to [=AV1 Image Sequences=]:
     - <assert>The AV1 level for High Profile shall be 5.1 or lower.</assert>
 
 <div class="example">
-A file containing items compliant with this profile is expected to list the following brands, in any order, in the <code>[=compatible_brands=]</code> of the <code>[=FileTypeBox=]</code>:
+A file containing items compliant with this profile is expected to list the following brands, in any order, in the <code>[=FileTypeBox=]</code>:
 
     <code>avif, mif1, miaf, MA1A</code>
 
-A file containing a <code>'[=pict=]'</code> track compliant with this profile is expected to list the following brands, in any order, in the <code>[=compatible_brands=]</code> of the <code>[=FileTypeBox=]</code>:
+A file containing a <code>'[=pict=]'</code> track compliant with this profile is expected to list the following brands, in any order, in the <code>[=FileTypeBox=]</code>:
 
     <code>avis, msf1, miaf, MA1A</code>
 </div>
@@ -1325,6 +1324,7 @@ The "Version(s)" column in the following table lists the version(s) of the boxes
     - EDITORIAL: <a href="https://github.com/AOMediaCodec/av1-avif/pull/267">Remove inconsistent dots in 9.1.2</a>
     - <a href="https://github.com/AOMediaCodec/av1-avif/pull/273">Change structure of optional table of boxes</a>
     - <a href="https://github.com/AOMediaCodec/av1-avif/pull/288">Add hidden image item recommendation</a>
+    - <a href="https://github.com/AOMediaCodec/av1-avif/pull/289">Remove mentions of ftyp compatible_brands</a>
 
 <h2 id="sato-examples">Appendix A: (informative) Sample Transform Derived Image Item Examples</h2>
 


### PR DESCRIPTION
In prevision of the major_brand field of the FileTypeBox not needing to be repeated in the compatible_brands field.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/y-guyon/av1-avif/pull/289.html" title="Last updated on Oct 23, 2024, 3:55 PM UTC (83856d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-avif/289/2acad7e...y-guyon:83856d0.html" title="Last updated on Oct 23, 2024, 3:55 PM UTC (83856d0)">Diff</a>