### PR TITLE
Run auto-publish.yml on ubuntu-latest

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   main:
     name: Deploy to GitHub pages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: w3c/spec-prod@v2


### PR DESCRIPTION
From [workflow failure](https://github.com/AOMediaCodec/av1-avif/actions/runs/12709639854/job/35429062013):

>    Bikeshed now requires Python 3.9; you are on 3.8.10.
        If you're seeing this message in your CI run, you are
        likely specifying an old OS; try `ubuntu-latest`.