### PR TITLE
Correct misspelling "bistream" to "bitstream"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -263,7 +263,7 @@ The semantics of the <code>'[=ispe=]'</code> property as defined in [[!HEIF]] ap
 
 NOTE: The dimensions indicated in the <code>'[=ispe=]'</code> property might not match the values <code>[=max_frame_width_minus1=]+1</code> and <code>[=max_frame_height_minus1=]+1</code> indicated in the AV1 bitstream.
 
-NOTE: The values of <code>[=render_width_minus1=]</code> and <code>[=render_height_minus1=]</code> possibly present in the AV1 bistream are not exposed at the [=/AVIF=] container level.
+NOTE: The values of <code>[=render_width_minus1=]</code> and <code>[=render_height_minus1=]</code> possibly present in the AV1 bitstream are not exposed at the [=/AVIF=] container level.
 
 <h4 id="clean-aperture-property">Clean Aperture Property</h4>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wantehchang/av1-avif/pull/311.html" title="Last updated on Apr 28, 2025, 6:21 PM UTC (0186eb6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-avif/311/aaea3c9...wantehchang:0186eb6.html" title="Last updated on Apr 28, 2025, 6:21 PM UTC (0186eb6)">Diff</a>